### PR TITLE
Let response only read headers and defer reading body

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -146,7 +146,7 @@ where
     /// The response is returned.
     pub async fn send<'m>(&mut self, request: Request<'m>, rx_buf: &'m mut [u8]) -> Result<Response<'m>, Error> {
         request.write(self).await?;
-        Response::read_headers(self, rx_buf).await
+        Response::read(self, rx_buf).await
     }
 }
 
@@ -240,7 +240,7 @@ where
     pub async fn send(mut self, rx_buf: &mut [u8]) -> Result<(Response, T), Error> {
         let request = self.request.build();
         request.write(&mut self.conn).await?;
-        let response = Response::read_headers(&mut self.conn, rx_buf).await?;
+        let response = Response::read(&mut self.conn, rx_buf).await?;
         Ok((response, self.conn))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -134,6 +134,22 @@ where
     Tls(S),
 }
 
+impl<T, S> HttpConnection<T, S>
+where
+    T: Read + Write,
+    S: Read + Write,
+{
+    /// Send a request on an already established connection.
+    ///
+    /// The response headers are stored in the provided rx_buf, which should be sized to contain at least the response headers.
+    ///
+    /// The response is returned.
+    pub async fn send<'m>(&mut self, request: Request<'m>, rx_buf: &'m mut [u8]) -> Result<Response<'m>, Error> {
+        request.write(self).await?;
+        Response::read_headers(self, rx_buf).await
+    }
+}
+
 impl<T, S> embedded_io::Io for HttpConnection<T, S>
 where
     T: Read + Write,
@@ -218,13 +234,13 @@ where
     /// Perform a HTTP request. A connection is created using the underlying client,
     /// and the request is written to the connection.
     ///
-    /// The response is stored in the provided rx_buf, which should be sized to contain the entire response.
+    /// The response headers are stored in the provided rx_buf, which should be sized to contain at least the response headers.
     ///
-    /// The returned response references data in the provided `rx_buf` argument.
-    pub async fn send<'m>(mut self, rx_buf: &'m mut [u8]) -> Result<Response<'m>, Error> {
+    /// The response together with the established connection is returned.
+    pub async fn send(mut self, rx_buf: &mut [u8]) -> Result<(Response, T), Error> {
         let request = self.request.build();
         request.write(&mut self.conn).await?;
-        let response = Response::read(&mut self.conn, rx_buf).await?;
-        Ok(response)
+        let response = Response::read_headers(&mut self.conn, rx_buf).await?;
+        Ok((response, self.conn))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,14 @@ pub enum Error {
     InvalidUrl,
     /// Tls Error
     Tls,
+    /// The provided buffer is too small
+    BufferTooSmall,
+}
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
 }
 
 impl From<embedded_io::ErrorKind> for Error {

--- a/src/response.rs
+++ b/src/response.rs
@@ -182,12 +182,12 @@ impl<C: Read> BodyReader<'_, C> {
             return Err(Error::BufferTooSmall);
         }
 
-        self.conn.read_exact(&mut buf[..to_read]).await.map_err(|e| match e {
+        self.read_exact(&mut buf[..to_read]).await.map_err(|e| match e {
             ReadExactError::UnexpectedEof => Error::Network(ErrorKind::Other),
-            ReadExactError::Other(e) => e.kind().into(),
+            ReadExactError::Other(e) => e,
         })?;
 
-        self.remaining.replace(0);
+        assert_eq!(0, self.remaining.unwrap_or_default());
 
         Ok(to_read)
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -21,7 +21,8 @@ pub struct Response<'a> {
 }
 
 impl<'a> Response<'a> {
-    pub async fn read_headers<C: Read>(conn: &mut C, header_buf: &'a mut [u8]) -> Result<Response<'a>, Error> {
+    // Read at least the headers from the connection.
+    pub async fn read<C: Read>(conn: &mut C, header_buf: &'a mut [u8]) -> Result<Response<'a>, Error> {
         let mut header_len = 0;
         let mut pos = 0;
         while pos < header_buf.len() {

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -42,7 +42,7 @@ async fn test_request_response() {
 
     request.write(&mut stream).await.unwrap();
     let mut rx_buf = [0; 4096];
-    let response = Response::read_headers(&mut stream, &mut rx_buf).await.unwrap();
+    let response = Response::read(&mut stream, &mut rx_buf).await.unwrap();
     let body = response.body(&mut stream).read_to_end().await;
 
     assert_eq!(body.unwrap(), b"PING");

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -42,9 +42,10 @@ async fn test_request_response() {
 
     request.write(&mut stream).await.unwrap();
     let mut rx_buf = [0; 4096];
-    let response = Response::read(&mut stream, &mut rx_buf).await.unwrap();
+    let response = Response::read_headers(&mut stream, &mut rx_buf).await.unwrap();
+    let body = response.body(&mut stream).read_to_end().await;
 
-    assert_eq!(response.body.unwrap(), b"PING");
+    assert_eq!(body.unwrap(), b"PING");
 
     tx.send(()).unwrap();
     t.await.unwrap();


### PR DESCRIPTION
This PR changes the current behavior of the Response type.
Previously the body was consumed when reading the response. This is now split in two so that only the headers are read to create the Response type. The user can then later read the response body.



TODO: How to handle if the user does not actually read the body? We should probably drain the connection in this case on Drop or something similar.