### PR TITLE
Add HttpEndpoint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -106,30 +106,30 @@ where
         }
     }
 
-    /// Create a connection to a server with the provided `endpoint_url`.
-    /// The path in the url is considered the base path for requests.
-    pub async fn endpoint<'m>(
+    /// Create a connection to a server with the provided `resource_url`.
+    /// The path in the url is considered the base path for subsequent requests.
+    pub async fn resource<'m>(
         &'m mut self,
-        endpoint_url: &'m str,
+        resource_url: &'m str,
     ) -> Result<
-        HttpEndpoint<'m, HttpConnection<T::Connection<'m>, TlsConnection<'m, T::Connection<'m>, Aes128GcmSha256>>>,
+        HttpResource<'m, HttpConnection<T::Connection<'m>, TlsConnection<'m, T::Connection<'m>, Aes128GcmSha256>>>,
         Error,
     > {
-        let endpoint_url = Url::parse(endpoint_url)?;
+        let resource_url = Url::parse(resource_url)?;
 
-        let conn = self.connect(&endpoint_url).await?;
-        Ok(HttpEndpoint {
+        let conn = self.connect(&resource_url).await?;
+        Ok(HttpResource {
             conn,
-            host: endpoint_url.host(),
-            base_path: endpoint_url.path(),
+            host: resource_url.host(),
+            base_path: resource_url.path(),
         })
     }
 }
 
-/// A HTTP endpoint
+/// A HTTP resource
 ///
 /// The underlying connection is closed when drop'ed.
-pub struct HttpEndpoint<'a, C>
+pub struct HttpResource<'a, C>
 where
     C: Read + Write,
 {
@@ -138,7 +138,7 @@ where
     pub base_path: &'a str,
 }
 
-impl<'a, C> HttpEndpoint<'a, C>
+impl<'a, C> HttpResource<'a, C>
 where
     C: Read + Write,
 {
@@ -193,9 +193,9 @@ where
         )
     }
 
-    /// Send a request to an endpoint.
+    /// Send a request to a resource.
     ///
-    /// The base path of the endpoint is prepended to the request path.
+    /// The base path of the resource is prepended to the request path.
     /// The response headers are stored in the provided rx_buf, which should be sized to contain at least the response headers.
     ///
     /// The response is returned.
@@ -227,7 +227,7 @@ where
 {
     /// Send a request on an established connection.
     ///
-    /// The request is sent in its raw form without any base path from the endpoint.
+    /// The request is sent in its raw form without any base path from the resource.
     /// The response headers are stored in the provided rx_buf, which should be sized to contain at least the response headers.
     ///
     /// The response is returned.

--- a/src/client.rs
+++ b/src/client.rs
@@ -215,7 +215,7 @@ where
 }
 
 /// A HTTP request handle
-/// 
+///
 /// The underlying connection is closed when drop'ed.
 pub struct HttpRequestHandle<'a, C>
 where
@@ -279,7 +279,6 @@ where
         self.request.unwrap().build()
     }
 }
-
 
 /// A HTTP resource describing a scoped endpoint
 ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -106,6 +106,8 @@ where
         }
     }
 
+    /// Create a connection to a server with the provided `endpoint_url`.
+    /// The path in the url is considered the base path for requests.
     pub async fn endpoint<'m>(
         &'m mut self,
         endpoint_url: &'m str,
@@ -124,9 +126,9 @@ where
     }
 }
 
-/// An HTTP endpoint
-/// 
-/// The connection is closed when drop'ed.
+/// A HTTP endpoint
+///
+/// The underlying connection is closed when drop'ed.
 pub struct HttpEndpoint<'a, C>
 where
     C: Read + Write,
@@ -145,36 +147,55 @@ where
     /// The returned request builder can be used to modify request parameters,
     /// before sending the request.
     pub fn request<'conn>(&'conn mut self, method: Method, path: &'a str) -> HttpRequestBuilder<'a, 'conn, C> {
-        HttpRequestBuilder::new(&mut self.conn, Request::new(method, path).host(self.host))
+        HttpRequestBuilder::new(
+            &mut self.conn,
+            Request::new(method, path).base_path(self.base_path).host(self.host),
+        )
     }
 
     /// Create a new GET http request.
     pub fn get<'conn>(&'conn mut self, path: &'a str) -> HttpRequestBuilder<'a, 'conn, C> {
-        HttpRequestBuilder::new(&mut self.conn, Request::get(path).host(self.host))
+        HttpRequestBuilder::new(
+            &mut self.conn,
+            Request::get(path).base_path(self.base_path).host(self.host),
+        )
     }
 
     /// Create a new POST http request.
     pub fn post<'conn>(&'conn mut self, path: &'a str) -> HttpRequestBuilder<'a, 'conn, C> {
-        HttpRequestBuilder::new(&mut self.conn, Request::post(path).host(self.host))
+        HttpRequestBuilder::new(
+            &mut self.conn,
+            Request::post(path).base_path(self.base_path).host(self.host),
+        )
     }
 
     /// Create a new PUT http request.
     pub fn put<'conn>(&'conn mut self, path: &'a str) -> HttpRequestBuilder<'a, 'conn, C> {
-        HttpRequestBuilder::new(&mut self.conn, Request::put(path).host(self.host))
+        HttpRequestBuilder::new(
+            &mut self.conn,
+            Request::put(path).base_path(self.base_path).host(self.host),
+        )
     }
 
     /// Create a new DELETE http request.
     pub fn delete<'conn>(&'conn mut self, path: &'a str) -> HttpRequestBuilder<'a, 'conn, C> {
-        HttpRequestBuilder::new(&mut self.conn, Request::delete(path).host(self.host))
+        HttpRequestBuilder::new(
+            &mut self.conn,
+            Request::delete(path).base_path(self.base_path).host(self.host),
+        )
     }
 
     /// Create a new HEAD http request.
     pub fn head<'conn>(&'conn mut self, path: &'a str) -> HttpRequestBuilder<'a, 'conn, C> {
-        HttpRequestBuilder::new(&mut self.conn, Request::head(path).host(self.host))
+        HttpRequestBuilder::new(
+            &mut self.conn,
+            Request::head(path).base_path(self.base_path).host(self.host),
+        )
     }
 
     /// Send a request to an endpoint.
     ///
+    /// The base path of the endpoint is prepended to the request path.
     /// The response headers are stored in the provided rx_buf, which should be sized to contain at least the response headers.
     ///
     /// The response is returned.
@@ -204,8 +225,9 @@ where
     T: Read + Write,
     S: Read + Write,
 {
-    /// Send a request on an already established connection.
+    /// Send a request on an established connection.
     ///
+    /// The request is sent in its raw form without any base path from the endpoint.
     /// The response headers are stored in the provided rx_buf, which should be sized to contain at least the response headers.
     ///
     /// The response is returned.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub enum Error {
     Tls(embedded_tls::TlsError),
     /// The provided buffer is too small
     BufferTooSmall,
+    /// The request is already sent
+    AlreadySent,
 }
 
 impl embedded_io::Error for Error {

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,6 +9,7 @@ use heapless::String;
 /// A read only HTTP request type
 pub struct Request<'a> {
     pub(crate) method: Method,
+    pub(crate) base_path: Option<&'a str>,
     pub(crate) path: &'a str,
     pub(crate) auth: Option<Auth<'a>>,
     pub(crate) host: Option<&'a str>,
@@ -21,6 +22,7 @@ impl<'a> Default for Request<'a> {
     fn default() -> Self {
         Self {
             method: Method::GET,
+            base_path: None,
             path: "/",
             auth: None,
             host: None,
@@ -43,6 +45,7 @@ pub enum Auth<'a> {
 
 impl<'a> Request<'a> {
     /// Create a new GET http request.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(method: Method, path: &'a str) -> RequestBuilder<'a> {
         RequestBuilder {
             request: Request {
@@ -115,6 +118,12 @@ impl<'a> Request<'a> {
     {
         write_str(c, self.method.as_str()).await?;
         write_str(c, " ").await?;
+        if let Some(base_path) = self.base_path {
+            write_str(c, base_path.trim_end_matches('/')).await?;
+            if !self.path.starts_with('/') {
+                write_str(c, "/").await?;
+            }
+        }
         write_str(c, self.path).await?;
         write_str(c, " HTTP/1.1\r\n").await?;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -184,6 +184,12 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Set the base path of the HTTP request.
+    pub(crate) fn base_path(mut self, base_path: &'a str) -> Self {
+        self.request.base_path = Some(base_path);
+        self
+    }
+
     /// Set the path of the HTTP request.
     pub fn path(mut self, path: &'a str) -> Self {
         self.request.path = path;

--- a/src/request.rs
+++ b/src/request.rs
@@ -34,8 +34,21 @@ impl<'a> Default for Request<'a> {
 }
 
 /// A HTTP request builder.
-pub struct RequestBuilder<'a> {
-    request: Request<'a>,
+pub trait RequestBuilder<'a> {
+    /// Set optional headers on the request.
+    fn headers(self, headers: &'a [(&'a str, &'a str)]) -> Self;
+    /// Set the path of the HTTP request.
+    fn path(self, path: &'a str) -> Self;
+    /// Set the data to send in the HTTP request body.
+    fn body(self, body: &'a [u8]) -> Self;
+    /// Set the host header.
+    fn host(self, host: &'a str) -> Self;
+    /// Set the content type header for the request.
+    fn content_type(self, content_type: ContentType) -> Self;
+    /// Set the basic authentication header for the request.
+    fn basic_auth(self, username: &'a str, password: &'a str) -> Self;
+    /// Return an immutable request.
+    fn build(self) -> Request<'a>;
 }
 
 /// Request authentication scheme.
@@ -44,71 +57,39 @@ pub enum Auth<'a> {
 }
 
 impl<'a> Request<'a> {
-    /// Create a new GET http request.
+    /// Create a new http request.
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(method: Method, path: &'a str) -> RequestBuilder<'a> {
-        RequestBuilder {
-            request: Request {
-                method,
-                path,
-                ..Default::default()
-            },
-        }
+    pub fn new(method: Method, path: &'a str) -> DefaultRequestBuilder<'a> {
+        DefaultRequestBuilder(Request {
+            method,
+            path,
+            ..Default::default()
+        })
     }
 
     /// Create a new GET http request.
-    pub fn get(path: &'a str) -> RequestBuilder<'a> {
-        RequestBuilder {
-            request: Request {
-                method: Method::GET,
-                path,
-                ..Default::default()
-            },
-        }
+    pub fn get(path: &'a str) -> DefaultRequestBuilder<'a> {
+        Self::new(Method::GET, path)
     }
 
     /// Create a new POST http request.
-    pub fn post(path: &'a str) -> RequestBuilder<'a> {
-        RequestBuilder {
-            request: Request {
-                method: Method::POST,
-                path,
-                ..Default::default()
-            },
-        }
+    pub fn post(path: &'a str) -> DefaultRequestBuilder<'a> {
+        Self::new(Method::POST, path)
     }
 
     /// Create a new PUT http request.
-    pub fn put(path: &'a str) -> RequestBuilder<'a> {
-        RequestBuilder {
-            request: Request {
-                method: Method::PUT,
-                path,
-                ..Default::default()
-            },
-        }
+    pub fn put(path: &'a str) -> DefaultRequestBuilder<'a> {
+        Self::new(Method::PUT, path)
     }
 
     /// Create a new DELETE http request.
-    pub fn delete(path: &'a str) -> RequestBuilder<'a> {
-        RequestBuilder {
-            request: Request {
-                method: Method::DELETE,
-                path,
-                ..Default::default()
-            },
-        }
+    pub fn delete(path: &'a str) -> DefaultRequestBuilder<'a> {
+        Self::new(Method::DELETE, path)
     }
 
     /// Create a new HEAD http request.
-    pub fn head(path: &'a str) -> RequestBuilder<'a> {
-        RequestBuilder {
-            request: Request {
-                method: Method::HEAD,
-                path,
-                ..Default::default()
-            },
-        }
+    pub fn head(path: &'a str) -> DefaultRequestBuilder<'a> {
+        Self::new(Method::HEAD, path)
     }
 
     /// Write request to the I/O stream
@@ -177,52 +158,41 @@ impl<'a> Request<'a> {
     }
 }
 
-impl<'a> RequestBuilder<'a> {
-    /// Set optional headers on the request.
-    pub fn headers(mut self, headers: &'a [(&'a str, &'a str)]) -> Self {
-        self.request.extra_headers.replace(headers);
+pub struct DefaultRequestBuilder<'a>(Request<'a>);
+
+impl<'a> RequestBuilder<'a> for DefaultRequestBuilder<'a> {
+    fn headers(mut self, headers: &'a [(&'a str, &'a str)]) -> Self {
+        self.0.extra_headers.replace(headers);
         self
     }
 
-    /// Set the base path of the HTTP request.
-    pub(crate) fn base_path(mut self, base_path: &'a str) -> Self {
-        self.request.base_path = Some(base_path);
+    fn path(mut self, path: &'a str) -> Self {
+        self.0.path = path;
         self
     }
 
-    /// Set the path of the HTTP request.
-    pub fn path(mut self, path: &'a str) -> Self {
-        self.request.path = path;
+    fn body(mut self, body: &'a [u8]) -> Self {
+        self.0.body.replace(body);
         self
     }
 
-    /// Set the data to send in the HTTP request body.
-    pub fn body(mut self, body: &'a [u8]) -> Self {
-        self.request.body.replace(body);
+    fn host(mut self, host: &'a str) -> Self {
+        self.0.host.replace(host);
         self
     }
 
-    /// Set the host header.
-    pub fn host(mut self, host: &'a str) -> Self {
-        self.request.host.replace(host);
+    fn content_type(mut self, content_type: ContentType) -> Self {
+        self.0.content_type.replace(content_type);
         self
     }
 
-    /// Set the content type header for the request.
-    pub fn content_type(mut self, content_type: ContentType) -> Self {
-        self.request.content_type.replace(content_type);
+    fn basic_auth(mut self, username: &'a str, password: &'a str) -> Self {
+        self.0.auth.replace(Auth::Basic { username, password });
         self
     }
 
-    /// Set the basic authentication header for the request.
-    pub fn basic_auth(mut self, username: &'a str, password: &'a str) -> Self {
-        self.request.auth.replace(Auth::Basic { username, password });
-        self
-    }
-
-    /// Return an immutable request.
-    pub fn build(self) -> Request<'a> {
-        self.request
+    fn build(self) -> Request<'a> {
+        self.0
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,4 @@
+use embedded_io::asynch::Write;
 use embedded_io::blocking::ReadExactError;
 use embedded_io::ErrorKind;
 use embedded_io::{asynch::Read, Error as _, Io};
@@ -9,7 +10,11 @@ use crate::Error;
 /// Type representing a parsed HTTP response.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Response<'a> {
+pub struct Response<'buf, 'conn, C>
+where
+    C: Read + Write,
+{
+    conn: &'conn mut C,
     /// The method used to create the response.
     method: Method,
     /// The HTTP response status code.
@@ -18,14 +23,21 @@ pub struct Response<'a> {
     pub content_type: Option<ContentType>,
     /// The content length.
     pub content_length: Option<usize>,
-    header_buf: &'a mut [u8],
+    header_buf: &'buf mut [u8],
     header_len: usize,
     body_pos: usize,
 }
 
-impl<'a> Response<'a> {
+impl<'buf, 'conn, C> Response<'buf, 'conn, C>
+where
+    C: Read + Write,
+{
     // Read at least the headers from the connection.
-    pub async fn read<C: Read>(conn: &mut C, method: Method, header_buf: &'a mut [u8]) -> Result<Response<'a>, Error> {
+    pub async fn read(
+        conn: &'conn mut C,
+        method: Method,
+        header_buf: &'buf mut [u8],
+    ) -> Result<Response<'buf, 'conn, C>, Error> {
         let mut header_len = 0;
         let mut pos = 0;
         while pos < header_buf.len() {
@@ -45,7 +57,7 @@ impl<'a> Response<'a> {
             let mut response = httparse::Response::new(&mut headers);
             let parse_status = response.parse(&header_buf[..pos]).map_err(|_| Error::Codec)?;
             if parse_status.is_complete() {
-                header_len = parse_status.unwrap().into();
+                header_len = parse_status.unwrap();
                 break;
             } else {
             }
@@ -89,6 +101,7 @@ impl<'a> Response<'a> {
         }
 
         Ok(Response {
+            conn,
             method,
             status,
             content_type,
@@ -109,14 +122,14 @@ impl<'a> Response<'a> {
     }
 
     /// Get the response body
-    pub fn body<'conn, C: Read>(self, conn: &'conn mut C) -> ResponseBody<'a, 'conn, C> {
+    pub fn body(self) -> ResponseBody<'buf, 'conn, C> {
         if self.method == Method::HEAD {
             // Head requests does not have a body so we return an empty reader
             ResponseBody {
                 body_buf: self.header_buf,
                 body_pos: 0,
                 reader: BodyReader {
-                    conn,
+                    conn: self.conn,
                     remaining: Some(0),
                 },
             }
@@ -130,7 +143,7 @@ impl<'a> Response<'a> {
             // The header buffer is now the body buffer
             let body_buf = header_buf;
             let reader = BodyReader {
-                conn,
+                conn: self.conn,
                 remaining: self.content_length.map(|cl| cl - self.body_pos),
             };
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,3 @@
-use embedded_io::asynch::Write;
 use embedded_io::blocking::ReadExactError;
 use embedded_io::ErrorKind;
 use embedded_io::{asynch::Read, Error as _, Io};
@@ -12,7 +11,7 @@ use crate::Error;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Response<'buf, 'conn, C>
 where
-    C: Read + Write,
+    C: Read,
 {
     conn: &'conn mut C,
     /// The method used to create the response.
@@ -30,7 +29,7 @@ where
 
 impl<'buf, 'conn, C> Response<'buf, 'conn, C>
 where
-    C: Read + Write,
+    C: Read,
 {
     // Read at least the headers from the connection.
     pub async fn read(

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -10,7 +10,7 @@ use rand::rngs::OsRng;
 use rand::RngCore;
 use reqwless::client::{HttpClient, TlsConfig, TlsVerify};
 use reqwless::response::Status;
-use reqwless::{headers::ContentType, request::Method};
+use reqwless::headers::ContentType;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Once;
 use tokio::net::TcpListener;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -52,8 +52,8 @@ async fn test_request_response_notls() {
     let url = format!("http://127.0.0.1:{}", addr.port());
     let mut client = HttpClient::new(&TCP, &LOOPBACK_DNS);
     let mut rx_buf = [0; 4096];
-    let mut endpoint = client.endpoint(&url).await.unwrap();
-    let response = endpoint
+    let mut resource = client.resource(&url).await.unwrap();
+    let response = resource
         .post("/")
         .body(b"PING")
         .content_type(ContentType::TextPlain)
@@ -115,8 +115,8 @@ async fn test_request_response_rustls() {
         TlsConfig::new(OsRng.next_u64(), &mut tls_buf, TlsVerify::None),
     );
     let mut rx_buf = [0; 4096];
-    let mut endpoint = client.endpoint(&url).await.unwrap();
-    let response = endpoint
+    let mut resource = client.resource(&url).await.unwrap();
+    let response = resource
         .post("/")
         .body(b"PING")
         .content_type(ContentType::TextPlain)
@@ -142,11 +142,11 @@ async fn test_request_response_drogue_cloud_sandbox() {
     );
     let mut rx_buf = [0; 4096];
 
-    // The endpoint must support TLS1.3
+    // The server must support TLS1.3
     // Also, if requests on embedded platforms fail with Error::Dns, then try to
     // enable the "alloc" feature on embedded-tls to enable RSA ciphers.
-    let mut endpoint = client.endpoint("https://http.sandbox.drogue.cloud/v1").await.unwrap();
-    let response = endpoint.post("/telemetry").send(&mut rx_buf).await.unwrap();
+    let mut resource = client.resource("https://http.sandbox.drogue.cloud/v1").await.unwrap();
+    let response = resource.post("/telemetry").send(&mut rx_buf).await.unwrap();
     assert_eq!(Status::Forbidden, response.status);
     let body = response.body().read_to_end().await.unwrap();
     assert!(!body.is_empty());

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -54,7 +54,7 @@ async fn test_request_response_notls() {
     let mut rx_buf = [0; 4096];
     let mut endpoint = client.endpoint(&url).await.unwrap();
     let response = endpoint
-        .request(Method::POST, "/")
+        .post("/")
         .body(b"PING")
         .content_type(ContentType::TextPlain)
         .send(&mut rx_buf)
@@ -117,7 +117,7 @@ async fn test_request_response_rustls() {
     let mut rx_buf = [0; 4096];
     let mut endpoint = client.endpoint(&url).await.unwrap();
     let response = endpoint
-        .request(Method::POST, "/")
+        .post("/")
         .body(b"PING")
         .content_type(ContentType::TextPlain)
         .send(&mut rx_buf)
@@ -146,11 +146,7 @@ async fn test_request_response_drogue_cloud_sandbox() {
     // Also, if requests on embedded platforms fail with Error::Dns, then try to
     // enable the "alloc" feature on embedded-tls to enable RSA ciphers.
     let mut endpoint = client.endpoint("https://http.sandbox.drogue.cloud/v1").await.unwrap();
-    let response = endpoint
-        .request(Method::POST, "/telemetry")
-        .send(&mut rx_buf)
-        .await
-        .unwrap();
+    let response = endpoint.post("/telemetry").send(&mut rx_buf).await.unwrap();
     assert_eq!(Status::Forbidden, response.status);
     let body = response.body().read_to_end().await.unwrap();
     assert!(!body.is_empty());

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -3,6 +3,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Server};
 use reqwless::request::Method;
 use reqwless::{headers::ContentType, request::Request, response::Response};
+use std::str::from_utf8;
 use std::sync::Once;
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
@@ -44,7 +45,7 @@ async fn test_request_response() {
     request.write(&mut stream).await.unwrap();
     let mut rx_buf = [0; 4096];
     let response = Response::read(&mut stream, Method::POST, &mut rx_buf).await.unwrap();
-    let body = response.body(&mut stream).read_to_end().await;
+    let body = response.body().read_to_end().await;
 
     assert_eq!(body.unwrap(), b"PING");
 
@@ -56,4 +57,14 @@ async fn echo(req: hyper::Request<Body>) -> Result<hyper::Response<Body>, hyper:
     match (req.method(), req.uri().path()) {
         _ => Ok(hyper::Response::new(req.into_body())),
     }
+}
+
+#[tokio::test]
+async fn write_without_base_path() {
+    let request = Request::get("/hello").build();
+
+    let mut buf = Vec::new();
+    request.write(&mut buf).await.unwrap();
+
+    assert!(from_utf8(&buf).unwrap().starts_with("GET /hello HTTP/1.1"));
 }

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -1,7 +1,7 @@
 use embedded_io::adapters::FromTokio;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Server};
-use reqwless::request::Method;
+use reqwless::request::{Method, RequestBuilder};
 use reqwless::{headers::ContentType, request::Request, response::Response};
 use std::str::from_utf8;
 use std::sync::Once;


### PR DESCRIPTION
This is a proposal for an easier to use api that propagates the underlying connection from when it is established using `HttpClient::endpoint()`.

It removes the ability to do:
```rust
let (response, mut conn) = HttpClient::request(Method::GET, "http://google.dk").await.unwrap().send(&mut rx_buf).await.unwrap();
response.body(&mut conn).read_to_end().await
```

which should now instead be

```rust
let mut endpoint = HttpClient::endpoint("http://google.dk").await;
endpoint.get("/").send(&mut rx_buf).await.unwrap().body().read_to_end().await
```

@lulf  Let me know what you think.