### PR TITLE
Make accessing response body infallible

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -133,7 +133,7 @@ where
     }
 
     /// Get the response body
-    pub fn body(self) -> Result<ResponseBody<'buf, 'conn, C>, Error> {
+    pub fn body(self) -> ResponseBody<'buf, 'conn, C> {
         let reader_hint = if self.method == Method::HEAD {
             // Head requests does not have a body so we return an empty reader
             ReaderHint::Empty
@@ -153,12 +153,12 @@ where
         // From now on, the header buffer is now the body buffer as all header bytes have been overwritten
         let body_buf = header_buf;
 
-        Ok(ResponseBody {
+        ResponseBody {
             conn: self.conn,
             reader_hint,
             body_buf,
             raw_body_read: self.raw_body_read,
-        })
+        }
     }
 }
 
@@ -597,7 +597,7 @@ mod tests {
             .await
             .unwrap();
 
-        let body = response.body().unwrap().read_to_end().await.unwrap();
+        let body = response.body().read_to_end().await.unwrap();
 
         assert_eq!(b"HELLO WORLD", body);
     }
@@ -611,13 +611,7 @@ mod tests {
             .unwrap();
 
         let mut body_buf = [0; 200];
-        let len = response
-            .body()
-            .unwrap()
-            .reader()
-            .read_to_end(&mut body_buf)
-            .await
-            .unwrap();
+        let len = response.body().reader().read_to_end(&mut body_buf).await.unwrap();
 
         assert_eq!(b"HELLO WORLD", &body_buf[..len]);
     }
@@ -630,7 +624,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(11, response.body().unwrap().discard().await.unwrap());
+        assert_eq!(11, response.body().discard().await.unwrap());
     }
 
     #[tokio::test]
@@ -643,13 +637,7 @@ mod tests {
             .unwrap();
 
         let mut body_buf = [0; 200];
-        let len = response
-            .body()
-            .unwrap()
-            .reader()
-            .read_to_end(&mut body_buf)
-            .await
-            .unwrap();
+        let len = response.body().reader().read_to_end(&mut body_buf).await.unwrap();
 
         assert_eq!(b"HELLO WORLD", &body_buf[..len]);
     }
@@ -663,7 +651,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(11, response.body().unwrap().discard().await.unwrap());
+        assert_eq!(11, response.body().discard().await.unwrap());
     }
 
     #[tokio::test]
@@ -674,7 +662,7 @@ mod tests {
             .await
             .unwrap();
 
-        let body = response.body().unwrap().read_to_end().await.unwrap();
+        let body = response.body().read_to_end().await.unwrap();
 
         assert_eq!(b"HELLO WORLD", body);
     }
@@ -688,13 +676,7 @@ mod tests {
             .unwrap();
 
         let mut body_buf = [0; 200];
-        let len = response
-            .body()
-            .unwrap()
-            .reader()
-            .read_to_end(&mut body_buf)
-            .await
-            .unwrap();
+        let len = response.body().reader().read_to_end(&mut body_buf).await.unwrap();
 
         assert_eq!(b"HELLO WORLD", &body_buf[..len]);
     }
@@ -707,7 +689,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(11, response.body().unwrap().discard().await.unwrap());
+        assert_eq!(11, response.body().discard().await.unwrap());
     }
 
     #[tokio::test]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -60,7 +60,7 @@ async fn test_request_response_notls() {
         .body(b"PING".as_slice())
         .content_type(ContentType::TextPlain);
     let response = request.send(&mut rx_buf).await.unwrap();
-    let body = response.body().unwrap().read_to_end().await;
+    let body = response.body().read_to_end().await;
     assert_eq!(body.unwrap(), b"PING");
 
     tx.send(()).unwrap();
@@ -96,7 +96,7 @@ async fn test_resource_notls() {
         .send(&mut rx_buf)
         .await
         .unwrap();
-    let body = response.body().unwrap().read_to_end().await;
+    let body = response.body().read_to_end().await;
     assert_eq!(body.unwrap(), b"PING");
 
     tx.send(()).unwrap();
@@ -160,7 +160,7 @@ async fn test_resource_rustls() {
         .send(&mut rx_buf)
         .await
         .unwrap();
-    let body = response.body().unwrap().read_to_end().await.unwrap();
+    let body = response.body().read_to_end().await.unwrap();
     assert_eq!(body, b"PING");
 
     tx.send(()).unwrap();
@@ -186,7 +186,7 @@ async fn test_resource_drogue_cloud_sandbox() {
     let mut resource = client.resource("https://http.sandbox.drogue.cloud/v1").await.unwrap();
     let response = resource.post("/telemetry").send(&mut rx_buf).await.unwrap();
     assert_eq!(Status::Forbidden, response.status);
-    let body = response.body().unwrap().read_to_end().await.unwrap();
+    let body = response.body().read_to_end().await.unwrap();
     assert!(!body.is_empty());
 }
 

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -45,7 +45,7 @@ async fn test_request_response() {
     request.write(&mut stream).await.unwrap();
     let mut rx_buf = [0; 4096];
     let response = Response::read(&mut stream, Method::POST, &mut rx_buf).await.unwrap();
-    let body = response.body().unwrap().read_to_end().await;
+    let body = response.body().read_to_end().await;
 
     assert_eq!(body.unwrap(), b"PING");
 


### PR DESCRIPTION
This is now possible because we support all possible response types