### PR TITLE
Fix error for keep-alive header

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -101,7 +101,7 @@ where
                     .push(header.value.try_into().map_err(|_| Error::Codec)?)
                     .map_err(|_| Error::Codec)?;
             } else if header.name.eq_ignore_ascii_case("keep-alive") {
-                keep_alive.replace(header.value.try_into().map_err(|_| Error::Codec));
+                keep_alive.replace(header.value.try_into().map_err(|_| Error::Codec)?);
             }
         }
 


### PR DESCRIPTION
Add missing `?` for the `map_err()` in `keep-alive` in the response, according to https://github.com/drogue-iot/reqwless/pull/36#issuecomment-1589203952