### PR TITLE
(hacky) update embedded-io to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ keywords = ["embedded", "async", "http", "no_std"]
 exclude = [".github"]
 
 [dependencies]
-buffered-io = { version = "0.1.0", features = ["async"] }
-embedded-io = { version = "0.4.0", features = ["async"] }
-embedded-nal-async = "0.4.0"
+buffered-io = { version = "0.3.0", features = ["async"] }
+embedded-io = { version = "0.5.0" }
+embedded-io-async = { version = "0.5.0" }
+embedded-nal-async = "0.5.0"
 httparse = { version = "1.8.0", default-features = false }
 heapless = "0.7"
 hex = { version = "0.4", default-features = false }
@@ -23,7 +24,7 @@ base64 = { version = "0.21.0", default-features = false }
 rand_core = { version = "0.6", default-features = true }
 log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
-embedded-tls = { version = "0.14", default-features = false, features = [
+embedded-tls = { version = "0.15", default-features = false, features = [
     "async",
 ], optional = true }
 rand_chacha = { version = "0.3", default-features = false }
@@ -34,7 +35,8 @@ hyper = { version = "0.14.23", features = ["full"] }
 tokio = { version = "1.21.2", features = ["full"] }
 tokio-rustls = { version = "0.23.4" }
 futures-util = { version = "0.3" }
-embedded-io = { version = "0.4", features = ["async", "tokio"] }
+embedded-io-async = { version = "0.5", features = ["std"] }
+embedded-io-adapters = { version = "0.5", features = ["std", "tokio-1"] }
 rustls-pemfile = "1.0"
 env_logger = "0.10"
 log = "0.4"
@@ -43,4 +45,10 @@ rand = "0.8"
 [features]
 default = ["embedded-tls"]
 alloc = ["embedded-tls?/alloc"]
-defmt = ["dep:defmt", "embedded-io/defmt", "embedded-tls?/defmt", "nourl/defmt"]
+defmt = [
+    "dep:defmt",
+    "embedded-io/defmt-03",
+    "embedded-io-async/defmt-03",
+    "embedded-tls?/defmt",
+    "nourl/defmt",
+]

--- a/src/concat.rs
+++ b/src/concat.rs
@@ -1,4 +1,5 @@
-use embedded_io::{asynch::Read, ErrorKind, Io};
+use embedded_io::{ErrorKind, ErrorType};
+use embedded_io_async::Read;
 
 pub struct ConcatReader<A, B>
 where
@@ -59,7 +60,7 @@ where
     }
 }
 
-impl<A, B> Io for ConcatReader<A, B>
+impl<A, B> ErrorType for ConcatReader<A, B>
 where
     A: Read,
     B: Read,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc = include_str!("../README.md")]
 use core::{num::ParseIntError, str::Utf8Error};
 
-use embedded_io::asynch::ReadExactError;
+use embedded_io_async::{ReadExactError, WriteAllError};
 
 mod fmt;
 
@@ -57,6 +57,18 @@ impl<E: embedded_io::Error> From<ReadExactError<E>> for Error {
         match value {
             ReadExactError::UnexpectedEof => Error::ConnectionClosed,
             ReadExactError::Other(e) => Error::Network(e.kind()),
+        }
+    }
+}
+
+impl<E> From<WriteAllError<E>> for Error
+where
+    E: embedded_io::Error,
+{
+    fn from(value: WriteAllError<E>) -> Self {
+        match value {
+            WriteAllError::WriteZero => Error::Network(embedded_io::ErrorKind::Other),
+            WriteAllError::Other(e) => Error::Network(e.kind()),
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,8 +3,8 @@ use crate::headers::ContentType;
 use crate::Error;
 use core::fmt::Write as _;
 use core::mem::size_of;
-use embedded_io::asynch::Write;
-use embedded_io::{Error as _, Io};
+use embedded_io::{Error as _, ErrorType};
+use embedded_io_async::{Write, WriteAllError};
 use heapless::String;
 
 /// A read only HTTP request type
@@ -169,7 +169,7 @@ where
                 Some(len) => {
                     trace!("Writing not-chunked body");
                     let mut writer = FixedBodyWriter(c, 0);
-                    body.write(&mut writer).await.map_err(|e| e.kind())?;
+                    body.write(&mut writer).await?;
 
                     if writer.1 != len {
                         return Err(Error::IncorrectBodyWritten);
@@ -178,7 +178,7 @@ where
                 None => {
                     trace!("Writing chunked body");
                     let mut writer = ChunkedBodyWriter(c, 0);
-                    body.write(&mut writer).await.map_err(|e| e.kind())?;
+                    body.write(&mut writer).await?;
 
                     write_str(c, "0\r\n\r\n").await?;
                 }
@@ -273,7 +273,7 @@ impl Method {
 }
 
 async fn write_str<C: Write>(c: &mut C, data: &str) -> Result<(), Error> {
-    c.write_all(data.as_bytes()).await.map_err(|e| e.kind())?;
+    c.write_all(data.as_bytes()).await?;
     Ok(())
 }
 
@@ -297,7 +297,7 @@ pub trait RequestBody {
     }
 
     /// Write the body to the provided writer
-    async fn write<W: Write>(&self, writer: &mut W) -> Result<(), W::Error>;
+    async fn write<W: Write>(&self, writer: &mut W) -> Result<(), WriteAllError<W::Error>>;
 }
 
 impl RequestBody for () {
@@ -305,7 +305,7 @@ impl RequestBody for () {
         None
     }
 
-    async fn write<W: Write>(&self, _writer: &mut W) -> Result<(), W::Error> {
+    async fn write<W: Write>(&self, _writer: &mut W) -> Result<(), WriteAllError<W::Error>> {
         Ok(())
     }
 }
@@ -315,7 +315,7 @@ impl RequestBody for &[u8] {
         Some(<[u8]>::len(self))
     }
 
-    async fn write<W: Write>(&self, writer: &mut W) -> Result<(), W::Error> {
+    async fn write<W: Write>(&self, writer: &mut W) -> Result<(), WriteAllError<W::Error>> {
         writer.write_all(self).await
     }
 }
@@ -328,7 +328,7 @@ where
         self.as_ref().map(|inner| inner.len()).unwrap_or_default()
     }
 
-    async fn write<W: Write>(&self, writer: &mut W) -> Result<(), W::Error> {
+    async fn write<W: Write>(&self, writer: &mut W) -> Result<(), WriteAllError<W::Error>> {
         if let Some(inner) = self.as_ref() {
             inner.write(writer).await
         } else {
@@ -339,7 +339,7 @@ where
 
 pub struct FixedBodyWriter<'a, C: Write>(&'a mut C, usize);
 
-impl<C> Io for FixedBodyWriter<'_, C>
+impl<C> ErrorType for FixedBodyWriter<'_, C>
 where
     C: Write,
 {
@@ -356,7 +356,7 @@ where
         Ok(written)
     }
 
-    async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), WriteAllError<Self::Error>> {
         self.0.write_all(buf).await?;
         self.1 += buf.len();
         Ok(())
@@ -369,11 +369,18 @@ where
 
 pub struct ChunkedBodyWriter<'a, C: Write>(&'a mut C, usize);
 
-impl<C> Io for ChunkedBodyWriter<'_, C>
+impl<C> ErrorType for ChunkedBodyWriter<'_, C>
 where
     C: Write,
 {
-    type Error = C::Error;
+    type Error = embedded_io::ErrorKind;
+}
+
+fn to_errorkind<E: embedded_io::Error>(e: WriteAllError<E>) -> embedded_io::ErrorKind {
+    match e {
+        WriteAllError::WriteZero => embedded_io::ErrorKind::Other,
+        WriteAllError::Other(e) => e.kind(),
+    }
 }
 
 impl<C> Write for ChunkedBodyWriter<'_, C>
@@ -381,31 +388,31 @@ where
     C: Write,
 {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.write_all(buf).await?;
+        self.write_all(buf).await.map_err(to_errorkind)?;
         Ok(buf.len())
     }
 
-    async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), WriteAllError<Self::Error>> {
         // Write chunk header
         let len = buf.len();
         let mut hex = [0; 2 * size_of::<usize>()];
         hex::encode_to_slice(len.to_be_bytes(), &mut hex).unwrap();
         let leading_zeros = hex.iter().position(|x| *x != b'0').unwrap_or_default();
         let (_, hex) = hex.split_at(leading_zeros);
-        self.0.write_all(hex).await?;
-        self.0.write_all(b"\r\n").await?;
+        self.0.write_all(hex).await.map_err(to_errorkind)?;
+        self.0.write_all(b"\r\n").await.map_err(to_errorkind)?;
 
         // Write chunk
-        self.0.write_all(buf).await?;
+        self.0.write_all(buf).await.map_err(to_errorkind)?;
         self.1 += len;
 
         // Write newline
-        self.0.write_all(b"\r\n").await?;
+        self.0.write_all(b"\r\n").await.map_err(to_errorkind)?;
         Ok(())
     }
 
     async fn flush(&mut self) -> Result<(), Self::Error> {
-        self.0.flush().await
+        self.0.flush().await.map_err(|e| e.kind())
     }
 }
 
@@ -415,7 +422,7 @@ mod tests {
 
     #[tokio::test]
     async fn basic_auth() {
-        let mut buffer = Vec::new();
+        let mut buffer: Vec<u8> = Vec::new();
         Request::new(Method::GET, "/")
             .basic_auth("username", "password")
             .build()
@@ -462,7 +469,7 @@ mod tests {
             None // Unknown length: triggers chunked body
         }
 
-        async fn write<W: Write>(&self, writer: &mut W) -> Result<(), W::Error> {
+        async fn write<W: Write>(&self, writer: &mut W) -> Result<(), WriteAllError<W::Error>> {
             writer.write_all(self.0).await
         }
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,5 @@
-use embedded_io::{asynch::Read, Error as _, Io};
+use embedded_io::{Error as _, ErrorType};
+use embedded_io_async::Read;
 use heapless::Vec;
 
 use crate::concat::ConcatReader;
@@ -333,7 +334,7 @@ where
     }
 }
 
-impl<B> embedded_io::Io for BodyReader<B>
+impl<B> ErrorType for BodyReader<B>
 where
     B: Read,
 {
@@ -360,7 +361,7 @@ pub struct FixedLengthBodyReader<B: Read> {
     remaining: usize,
 }
 
-impl<C: Read> Io for FixedLengthBodyReader<C> {
+impl<C: Read> ErrorType for FixedLengthBodyReader<C> {
     type Error = Error;
 }
 
@@ -403,7 +404,7 @@ impl<C: Read> ChunkedBodyReader<C> {
     }
 }
 
-impl<C: Read> Io for ChunkedBodyReader<C> {
+impl<C: Read> ErrorType for ChunkedBodyReader<C> {
     type Error = Error;
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,7 +1,7 @@
 #![feature(async_fn_in_trait)]
 #![feature(impl_trait_projections)]
 #![allow(incomplete_features)]
-use embedded_io::adapters::FromTokio;
+use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_nal_async::{AddrType, IpAddr, Ipv4Addr};
 use hyper::server::conn::Http;
 use hyper::service::{make_service_fn, service_fn};

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -1,4 +1,4 @@
-use embedded_io::adapters::FromTokio;
+use embedded_io_adapters::tokio_1::FromTokio;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Server};
 use reqwless::request::{Method, RequestBuilder};


### PR DESCRIPTION
I realize there is already discussion and plans to address this in #39 but I had the urge to update my hobby embassy project _now_: ;)

I'm still posting it, in case someone finds it useful

I mostly propagate WriteAllError or collapse it down to `embedded_io::ErrorKind` when that's not an option. 

