### PR TITLE
Remove explicit error conversion

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -110,8 +110,7 @@ where
                 let mut conn: embedded_tls::TlsConnection<'m, T::Connection<'m>, embedded_tls::Aes128GcmSha256> =
                     embedded_tls::TlsConnection::new(conn, tls.read_buffer, tls.write_buffer);
                 conn.open::<_, embedded_tls::NoVerify>(TlsContext::new(&config, &mut rng))
-                    .await
-                    .map_err(Error::Tls)?;
+                    .await?;
                 Ok(HttpConnection::Tls(conn))
             } else {
                 Ok(HttpConnection::Plain(conn))


### PR DESCRIPTION
There's a `From<>` impl that is automatically called by the question mark operator. This wasn't the only change I meant to do with errors, but... baby steps