### PR TITLE
Ensure that the final chunk end termination is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fix regression introduced in v0.9.0 when reading chunked body where the final newline is not read (#58)
+
 ## [v0.9.0](https://github.com/drogue-iot/reqwless/compare/v0.8.0...v0.9.0) (2023-10-30)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Fix regression introduced in v0.9.0 when reading chunked body where the final newline is not read (#58)
+* Fix regression introduced in v0.9.0 when reading chunked body where the final newline is not read ([#58](https://github.com/drogue-iot/reqwless/pull/58))
 
 ## [v0.9.0](https://github.com/drogue-iot/reqwless/compare/v0.8.0...v0.9.0) (2023-10-30)
 


### PR DESCRIPTION
This fixes a regression introduced with `BufRead` support.

This replaces the commits I made to #57.