### PR TITLE
Allow read_to_end with ChunkedEncoding

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,9 +3,9 @@ use embedded_io_async::{BufRead, Read};
 
 use crate::TryBufRead;
 
-struct ReadBuffer<'buf> {
-    buffer: &'buf mut [u8],
-    loaded: usize,
+pub struct ReadBuffer<'buf> {
+    pub buffer: &'buf mut [u8],
+    pub loaded: usize,
 }
 
 impl<'buf> ReadBuffer<'buf> {
@@ -46,8 +46,8 @@ pub struct BufferingReader<'resp, 'buf, B>
 where
     B: Read,
 {
-    buffer: ReadBuffer<'buf>,
-    stream: &'resp mut B,
+    pub buffer: ReadBuffer<'buf>,
+    pub stream: &'resp mut B,
 }
 
 impl<'resp, 'buf, B> BufferingReader<'resp, 'buf, B>

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,7 +3,7 @@ use embedded_io_async::{BufRead, Read};
 
 use crate::TryBufRead;
 
-pub struct ReadBuffer<'buf> {
+pub(crate) struct ReadBuffer<'buf> {
     pub buffer: &'buf mut [u8],
     pub loaded: usize,
 }
@@ -46,8 +46,8 @@ pub struct BufferingReader<'resp, 'buf, B>
 where
     B: Read,
 {
-    pub buffer: ReadBuffer<'buf>,
-    pub stream: &'resp mut B,
+    pub(crate) buffer: ReadBuffer<'buf>,
+    pub(crate) stream: &'resp mut B,
 }
 
 impl<'resp, 'buf, B> BufferingReader<'resp, 'buf, B>

--- a/src/response/chunked.rs
+++ b/src/response/chunked.rs
@@ -31,7 +31,7 @@ impl ChunkState {
 
 /// Chunked response body reader
 pub struct ChunkedBodyReader<B> {
-    raw_body: B,
+    pub raw_body: B,
     chunk_remaining: ChunkState,
 }
 

--- a/src/response/chunked.rs
+++ b/src/response/chunked.rs
@@ -1,0 +1,178 @@
+use embedded_io_async::{BufRead, Error as _, ErrorType, Read};
+
+use crate::Error;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ChunkState {
+    NoChunk,
+    NotEmpty(u32),
+    Empty,
+}
+
+impl ChunkState {
+    fn consume(&mut self, amt: usize) -> usize {
+        if let ChunkState::NotEmpty(remaining) = self {
+            let consumed = (amt as u32).min(*remaining);
+            *remaining -= consumed;
+            consumed as usize
+        } else {
+            0
+        }
+    }
+
+    fn len(self) -> usize {
+        if let ChunkState::NotEmpty(len) = self {
+            len as usize
+        } else {
+            0
+        }
+    }
+}
+
+/// Chunked response body reader
+pub struct ChunkedBodyReader<B> {
+    raw_body: B,
+    chunk_remaining: ChunkState,
+}
+
+impl<C> ChunkedBodyReader<C>
+where
+    C: Read,
+{
+    pub fn new(raw_body: C) -> Self {
+        Self {
+            raw_body,
+            chunk_remaining: ChunkState::NoChunk,
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.chunk_remaining == ChunkState::Empty
+    }
+
+    async fn read_next_chunk_length(&mut self) -> Result<(), Error> {
+        let mut header_buf = [0; 8 + 2]; // 32 bit hex + \r + \n
+        let mut total_read = 0;
+
+        'read_size: loop {
+            let mut byte = 0;
+            self.raw_body
+                .read_exact(core::slice::from_mut(&mut byte))
+                .await
+                .map_err(|e| Error::from(e).kind())?;
+
+            if byte != b'\n' {
+                header_buf[total_read] = byte;
+                total_read += 1;
+
+                if total_read == header_buf.len() {
+                    return Err(Error::Codec);
+                }
+            } else {
+                if total_read == 0 || header_buf[total_read - 1] != b'\r' {
+                    return Err(Error::Codec);
+                }
+                break 'read_size;
+            }
+        }
+
+        let hex_digits = total_read - 1;
+
+        // Prepend hex with zeros
+        let mut hex = [b'0'; 8];
+        hex[8 - hex_digits..].copy_from_slice(&header_buf[..hex_digits]);
+
+        let mut bytes = [0; 4];
+        hex::decode_to_slice(hex, &mut bytes).map_err(|_| Error::Codec)?;
+
+        let chunk_length = u32::from_be_bytes(bytes);
+
+        debug!("Chunk length: {}", chunk_length);
+
+        self.chunk_remaining = match chunk_length {
+            0 => ChunkState::Empty,
+            other => ChunkState::NotEmpty(other),
+        };
+
+        Ok(())
+    }
+
+    async fn read_chunk_end(&mut self) -> Result<(), Error> {
+        // All chunks are terminated with a \r\n
+        let mut newline_buf = [0; 2];
+        self.raw_body.read_exact(&mut newline_buf).await?;
+
+        if newline_buf != [b'\r', b'\n'] {
+            return Err(Error::Codec);
+        }
+        Ok(())
+    }
+
+    /// Handles chunk boundary and returns the number of bytes in the current (or new) chunk.
+    async fn handle_chunk_boundary(&mut self) -> Result<usize, Error> {
+        match self.chunk_remaining {
+            ChunkState::NoChunk => self.read_next_chunk_length().await?,
+
+            ChunkState::NotEmpty(0) => {
+                // The current chunk is currently empty, advance into a new chunk...
+                self.read_chunk_end().await?;
+                self.read_next_chunk_length().await?;
+            }
+
+            ChunkState::NotEmpty(_) => {}
+
+            ChunkState::Empty => return Ok(0),
+        }
+
+        if self.chunk_remaining == ChunkState::Empty {
+            // Read final chunk termination
+            self.read_chunk_end().await?;
+        }
+
+        Ok(self.chunk_remaining.len())
+    }
+}
+
+impl<C> ErrorType for ChunkedBodyReader<C> {
+    type Error = Error;
+}
+
+impl<C> Read for ChunkedBodyReader<C>
+where
+    C: Read,
+{
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        let remaining = self.handle_chunk_boundary().await?;
+        let max_len = buf.len().min(remaining);
+
+        let len = self
+            .raw_body
+            .read(&mut buf[..max_len])
+            .await
+            .map_err(|e| Error::Network(e.kind()))?;
+
+        self.chunk_remaining.consume(len);
+
+        Ok(len)
+    }
+}
+
+impl<C> BufRead for ChunkedBodyReader<C>
+where
+    C: BufRead + Read,
+{
+    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        let remaining = self.handle_chunk_boundary().await?;
+
+        let buf = self.raw_body.fill_buf().await.map_err(|e| Error::Network(e.kind()))?;
+
+        let len = buf.len().min(remaining);
+
+        Ok(&buf[..len])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        let consumed = self.chunk_remaining.consume(amt);
+        self.raw_body.consume(consumed);
+    }
+}

--- a/src/response/chunked.rs
+++ b/src/response/chunked.rs
@@ -156,7 +156,7 @@ where
         };
 
         let mut len = 0;
-        while len < reader.raw_body.buffer.buffer.len() {
+        while !reader.raw_body.buffer.buffer.is_empty() {
             // Read some
             let read = reader.fill_buf().await?.len();
             len += read;

--- a/src/response/chunked.rs
+++ b/src/response/chunked.rs
@@ -182,6 +182,10 @@ where
             reader.raw_body.buffer.buffer = &mut reader.raw_body.buffer.buffer[consumed_from_buffer..];
         }
 
+        if !reader.is_done() {
+            return Err(Error::BufferTooSmall);
+        }
+
         Ok(&mut buffer[..len])
     }
 }

--- a/src/response/fixed_length.rs
+++ b/src/response/fixed_length.rs
@@ -1,0 +1,59 @@
+use embedded_io_async::{BufRead, Error as _, ErrorType, Read};
+
+use crate::Error;
+
+/// Fixed length response body reader
+pub struct FixedLengthBodyReader<B> {
+    pub raw_body: B,
+    pub remaining: usize,
+}
+
+impl<C> ErrorType for FixedLengthBodyReader<C> {
+    type Error = Error;
+}
+
+impl<C> Read for FixedLengthBodyReader<C>
+where
+    C: Read,
+{
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        if self.remaining == 0 {
+            return Ok(0);
+        }
+
+        let read = self.raw_body.read(buf).await.map_err(|e| Error::Network(e.kind()))?;
+        self.remaining -= read;
+
+        Ok(read)
+    }
+}
+
+impl<C> BufRead for FixedLengthBodyReader<C>
+where
+    C: BufRead + Read,
+{
+    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        if self.remaining == 0 {
+            return Ok(&[]);
+        }
+
+        let loaded = self
+            .raw_body
+            .fill_buf()
+            .await
+            .map_err(|e| Error::Network(e.kind()))
+            .map(|data| &data[..data.len().min(self.remaining)])?;
+
+        if loaded.is_empty() {
+            return Err(Error::ConnectionAborted);
+        }
+
+        Ok(loaded)
+    }
+
+    fn consume(&mut self, amt: usize) {
+        let amt = amt.min(self.remaining);
+        self.remaining -= amt;
+        self.raw_body.consume(amt)
+    }
+}

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -592,6 +592,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn can_read_to_end_with_chunked_encoding() {
+        let mut conn = FakeSingleReadConnection::new(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHELLO\r\n6\r\n WORLD\r\n0\r\n\r\n",
+        );
+        let mut header_buf = [0; 200];
+        let response = Response::read(&mut conn, Method::GET, &mut header_buf).await.unwrap();
+
+        let body = response.body().read_to_end().await.unwrap();
+
+        assert_eq!(b"HELLO WORLD", body);
+        assert!(conn.is_exhausted());
+    }
+
+    #[tokio::test]
     async fn can_read_to_end_of_connection_with_same_buffer() {
         let mut conn = FakeSingleReadConnection::new(b"HTTP/1.1 200 OK\r\n\r\nHELLO WORLD");
         let mut header_buf = [0; 200];

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -235,11 +235,6 @@ where
 {
     /// Read the entire body into the buffer originally provided [`Response::read()`].
     /// This requires that this original buffer is large enough to contain the entire body.
-    ///
-    /// This is not valid for chunked responses as it requires that the body bytes over-read
-    /// while parsing the http response header would be available for the body reader.
-    /// For this case, or if the original buffer is not large enough, use
-    /// [`BodyReader::read_to_end()`] instead from the reader returned by [`ResponseBody::reader()`].
     pub async fn read_to_end(self) -> Result<&'buf mut [u8], Error> {
         // We can only read responses with Content-Length header to end using the body_buf buffer,
         // as any other response would require the body reader to know the entire body.

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -5,7 +5,12 @@ use heapless::Vec;
 use crate::headers::{ContentType, KeepAlive, TransferEncoding};
 use crate::reader::BufferingReader;
 use crate::request::Method;
+use crate::response::chunked::ChunkedBodyReader;
+use crate::response::fixed_length::FixedLengthBodyReader;
 use crate::Error;
+
+mod chunked;
+mod fixed_length;
 
 /// Type representing a parsed HTTP response.
 #[derive(Debug)]
@@ -211,10 +216,7 @@ where
                 raw_body,
                 remaining: content_length,
             }),
-            ReaderHint::Chunked => BodyReader::Chunked(ChunkedBodyReader {
-                raw_body,
-                chunk_remaining: ChunkState::NoChunk,
-            }),
+            ReaderHint::Chunked => BodyReader::Chunked(ChunkedBodyReader::new(raw_body)),
             ReaderHint::ToEnd => BodyReader::ToEnd(raw_body),
         }
     }
@@ -303,7 +305,7 @@ where
                 }
                 reader.remaining == 0
             }
-            BodyReader::Chunked(reader) => reader.chunk_remaining == ChunkState::Empty,
+            BodyReader::Chunked(reader) => reader.is_done(),
             BodyReader::ToEnd(_) => true,
         };
 
@@ -367,226 +369,6 @@ where
             BodyReader::Chunked(reader) => reader.consume(amt),
             BodyReader::ToEnd(conn) => conn.consume(amt),
         }
-    }
-}
-
-/// Fixed length response body reader
-pub struct FixedLengthBodyReader<B> {
-    raw_body: B,
-    remaining: usize,
-}
-
-impl<C> ErrorType for FixedLengthBodyReader<C> {
-    type Error = Error;
-}
-
-impl<C> Read for FixedLengthBodyReader<C>
-where
-    C: Read,
-{
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
-        if self.remaining == 0 {
-            return Ok(0);
-        }
-
-        let read = self.raw_body.read(buf).await.map_err(|e| Error::Network(e.kind()))?;
-        self.remaining -= read;
-
-        Ok(read)
-    }
-}
-
-impl<C> BufRead for FixedLengthBodyReader<C>
-where
-    C: BufRead + Read,
-{
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
-        if self.remaining == 0 {
-            return Ok(&[]);
-        }
-
-        let loaded = self
-            .raw_body
-            .fill_buf()
-            .await
-            .map_err(|e| Error::Network(e.kind()))
-            .map(|data| &data[..data.len().min(self.remaining)])?;
-
-        if loaded.is_empty() {
-            return Err(Error::ConnectionAborted);
-        }
-
-        Ok(loaded)
-    }
-
-    fn consume(&mut self, amt: usize) {
-        let amt = amt.min(self.remaining);
-        self.remaining -= amt;
-        self.raw_body.consume(amt)
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ChunkState {
-    NoChunk,
-    NotEmpty(u32),
-    Empty,
-}
-
-impl ChunkState {
-    fn consume(&mut self, amt: usize) -> usize {
-        if let ChunkState::NotEmpty(remaining) = self {
-            let consumed = (amt as u32).min(*remaining);
-            *remaining -= consumed;
-            consumed as usize
-        } else {
-            0
-        }
-    }
-
-    fn len(self) -> usize {
-        if let ChunkState::NotEmpty(len) = self {
-            len as usize
-        } else {
-            0
-        }
-    }
-}
-
-/// Chunked response body reader
-pub struct ChunkedBodyReader<B> {
-    raw_body: B,
-    chunk_remaining: ChunkState,
-}
-
-impl<C> ChunkedBodyReader<C>
-where
-    C: Read,
-{
-    async fn read_next_chunk_length(&mut self) -> Result<(), Error> {
-        let mut header_buf = [0; 8 + 2]; // 32 bit hex + \r + \n
-        let mut total_read = 0;
-
-        'read_size: loop {
-            let mut byte = 0;
-            self.raw_body
-                .read_exact(core::slice::from_mut(&mut byte))
-                .await
-                .map_err(|e| Error::from(e).kind())?;
-
-            if byte != b'\n' {
-                header_buf[total_read] = byte;
-                total_read += 1;
-
-                if total_read == header_buf.len() {
-                    return Err(Error::Codec);
-                }
-            } else {
-                if total_read == 0 || header_buf[total_read - 1] != b'\r' {
-                    return Err(Error::Codec);
-                }
-                break 'read_size;
-            }
-        }
-
-        let hex_digits = total_read - 1;
-
-        // Prepend hex with zeros
-        let mut hex = [b'0'; 8];
-        hex[8 - hex_digits..].copy_from_slice(&header_buf[..hex_digits]);
-
-        let mut bytes = [0; 4];
-        hex::decode_to_slice(hex, &mut bytes).map_err(|_| Error::Codec)?;
-
-        let chunk_length = u32::from_be_bytes(bytes);
-
-        debug!("Chunk length: {}", chunk_length);
-
-        self.chunk_remaining = match chunk_length {
-            0 => ChunkState::Empty,
-            other => ChunkState::NotEmpty(other),
-        };
-
-        Ok(())
-    }
-
-    async fn read_chunk_end(&mut self) -> Result<(), Error> {
-        // All chunks are terminated with a \r\n
-        let mut newline_buf = [0; 2];
-        self.raw_body.read_exact(&mut newline_buf).await?;
-
-        if newline_buf != [b'\r', b'\n'] {
-            return Err(Error::Codec);
-        }
-        Ok(())
-    }
-
-    /// Handles chunk boundary and returns the number of bytes in the current (or new) chunk.
-    async fn handle_chunk_boundary(&mut self) -> Result<usize, Error> {
-        match self.chunk_remaining {
-            ChunkState::NoChunk => self.read_next_chunk_length().await?,
-
-            ChunkState::NotEmpty(0) => {
-                // The current chunk is currently empty, advance into a new chunk...
-                self.read_chunk_end().await?;
-                self.read_next_chunk_length().await?;
-            }
-
-            ChunkState::NotEmpty(_) => {}
-
-            ChunkState::Empty => return Ok(0),
-        }
-
-        if self.chunk_remaining == ChunkState::Empty {
-            // Read final chunk termination
-            self.read_chunk_end().await?;
-        }
-
-        Ok(self.chunk_remaining.len())
-    }
-}
-
-impl<C> ErrorType for ChunkedBodyReader<C> {
-    type Error = Error;
-}
-
-impl<C> Read for ChunkedBodyReader<C>
-where
-    C: Read,
-{
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
-        let remaining = self.handle_chunk_boundary().await?;
-        let max_len = buf.len().min(remaining);
-
-        let len = self
-            .raw_body
-            .read(&mut buf[..max_len])
-            .await
-            .map_err(|e| Error::Network(e.kind()))?;
-
-        self.chunk_remaining.consume(len);
-
-        Ok(len)
-    }
-}
-
-impl<C> BufRead for ChunkedBodyReader<C>
-where
-    C: BufRead + Read,
-{
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
-        let remaining = self.handle_chunk_boundary().await?;
-
-        let buf = self.raw_body.fill_buf().await.map_err(|e| Error::Network(e.kind()))?;
-
-        let len = buf.len().min(remaining);
-
-        Ok(&buf[..len])
-    }
-
-    fn consume(&mut self, amt: usize) {
-        let consumed = self.chunk_remaining.consume(amt);
-        self.raw_body.consume(consumed);
     }
 }
 
@@ -693,7 +475,7 @@ mod tests {
     use crate::{
         reader::BufferingReader,
         request::Method,
-        response::{ChunkState, ChunkedBodyReader, Response},
+        response::{chunked::ChunkedBodyReader, Response},
         Error,
     };
 
@@ -841,10 +623,7 @@ mod tests {
     async fn chunked_body_reader_can_read_with_large_buffer() {
         let mut raw_body = b"1\r\nX\r\n10\r\nYYYYYYYYYYYYYYYY\r\n0\r\n\r\n".as_slice();
         let mut read_buffer = [0; 128];
-        let mut reader = ChunkedBodyReader {
-            raw_body: BufferingReader::new(&mut read_buffer, 0, &mut raw_body),
-            chunk_remaining: ChunkState::NoChunk,
-        };
+        let mut reader = ChunkedBodyReader::new(BufferingReader::new(&mut read_buffer, 0, &mut raw_body));
 
         let mut body = [0; 17];
         reader.read_exact(&mut body).await.unwrap();
@@ -858,10 +637,7 @@ mod tests {
     async fn chunked_body_reader_can_read_with_tiny_buffer() {
         let mut raw_body = b"1\r\nX\r\n10\r\nYYYYYYYYYYYYYYYY\r\n0\r\n\r\n".as_slice();
         let mut read_buffer = [0; 128];
-        let mut reader = ChunkedBodyReader {
-            raw_body: BufferingReader::new(&mut read_buffer, 0, &mut raw_body),
-            chunk_remaining: ChunkState::NoChunk,
-        };
+        let mut reader = ChunkedBodyReader::new(BufferingReader::new(&mut read_buffer, 0, &mut raw_body));
 
         let mut body = heapless::Vec::<u8, 17>::new();
         for _ in 0..17 {

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -1,0 +1,93 @@
+use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_io_async::{ErrorType, Read, Write};
+use embedded_nal_async::{AddrType, IpAddr, Ipv4Addr};
+use reqwless::TryBufRead;
+use std::net::{SocketAddr, ToSocketAddrs};
+use tokio::net::TcpStream;
+
+#[derive(Debug)]
+pub struct TestError;
+
+impl embedded_io::Error for TestError {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}
+
+pub struct LoopbackDns;
+impl embedded_nal_async::Dns for LoopbackDns {
+    type Error = TestError;
+
+    async fn get_host_by_name(&self, _: &str, _: AddrType) -> Result<IpAddr, Self::Error> {
+        Ok(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+    }
+
+    async fn get_host_by_address(&self, _: IpAddr, _: &mut [u8]) -> Result<usize, Self::Error> {
+        Err(TestError)
+    }
+}
+
+pub struct StdDns;
+
+impl embedded_nal_async::Dns for StdDns {
+    type Error = std::io::Error;
+
+    async fn get_host_by_name(&self, host: &str, addr_type: AddrType) -> Result<IpAddr, Self::Error> {
+        for address in (host, 0).to_socket_addrs()? {
+            match address {
+                SocketAddr::V4(a) if addr_type == AddrType::IPv4 || addr_type == AddrType::Either => {
+                    return Ok(IpAddr::V4(a.ip().octets().into()))
+                }
+                SocketAddr::V6(a) if addr_type == AddrType::IPv6 || addr_type == AddrType::Either => {
+                    return Ok(IpAddr::V6(a.ip().octets().into()))
+                }
+                _ => {}
+            }
+        }
+        Err(std::io::ErrorKind::AddrNotAvailable.into())
+    }
+
+    async fn get_host_by_address(&self, _: IpAddr, _: &mut [u8]) -> Result<usize, Self::Error> {
+        todo!()
+    }
+}
+
+pub struct TokioTcp;
+pub struct TokioStream(pub(crate) FromTokio<TcpStream>);
+
+impl TryBufRead for TokioStream {}
+
+impl ErrorType for TokioStream {
+    type Error = <FromTokio<TcpStream> as ErrorType>::Error;
+}
+
+impl Read for TokioStream {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.0.read(buf).await
+    }
+}
+
+impl Write for TokioStream {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.0.write(buf).await
+    }
+}
+
+impl embedded_nal_async::TcpConnect for TokioTcp {
+    type Error = std::io::Error;
+    type Connection<'m> = TokioStream;
+
+    async fn connect<'m>(
+        &'m self,
+        remote: embedded_nal_async::SocketAddr,
+    ) -> Result<Self::Connection<'m>, Self::Error> {
+        let ip = match remote {
+            embedded_nal_async::SocketAddr::V4(a) => a.ip().octets().into(),
+            embedded_nal_async::SocketAddr::V6(a) => a.ip().octets().into(),
+        };
+        let remote = SocketAddr::new(ip, remote.port());
+        let stream = TcpStream::connect(remote).await?;
+        let stream = FromTokio::new(stream);
+        Ok(TokioStream(stream))
+    }
+}

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -3,6 +3,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Server};
 use reqwless::client::HttpConnection;
 use reqwless::request::{Method, RequestBuilder};
+use reqwless::Error;
 use reqwless::{headers::ContentType, request::Request, response::Response};
 use std::str::from_utf8;
 use std::sync::Once;
@@ -91,6 +92,13 @@ async fn google_panic() {
 
     let mut rx_buf = [0; 8 * 1024];
     let resp = Response::read(&mut conn, Method::GET, &mut rx_buf).await.unwrap();
-    let body = resp.body().read_to_end().await.unwrap();
-    println!("{} -> {}", body.len(), core::str::from_utf8(&body).unwrap());
+    let result = resp.body().read_to_end().await;
+
+    match result {
+        Ok(body) => {
+            println!("{} -> {}", body.len(), core::str::from_utf8(&body).unwrap());
+        }
+        Err(Error::BufferTooSmall) => println!("Buffer too small"),
+        Err(e) => panic!("Unexpected error: {e:?}"),
+    }
 }

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -73,3 +73,24 @@ async fn write_without_base_path() {
 
     assert!(from_utf8(&buf).unwrap().starts_with("GET /hello HTTP/1.1"));
 }
+
+#[tokio::test]
+async fn google_panic() {
+    use std::net::SocketAddr;
+    let google_ip = [142, 250, 74, 110];
+    let addr = SocketAddr::from((google_ip, 80));
+
+    let conn = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let mut conn = TokioStream(FromTokio::new(conn));
+
+    let request = Request::get("/")
+        .host("www.google.com")
+        .content_type(ContentType::TextPlain)
+        .build();
+    request.write(&mut conn).await.unwrap();
+
+    let mut rx_buf = [0; 8 * 1024];
+    let resp = Response::read(&mut conn, Method::GET, &mut rx_buf).await.unwrap();
+    let body = resp.body().read_to_end().await.unwrap();
+    println!("{} -> {}", body.len(), core::str::from_utf8(&body).unwrap());
+}

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -9,6 +9,10 @@ use std::sync::Once;
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
 
+mod connection;
+
+use connection::*;
+
 static INIT: Once = Once::new();
 
 fn setup() {
@@ -36,7 +40,7 @@ async fn test_request_response() {
     });
 
     let stream = TcpStream::connect(addr).await.unwrap();
-    let mut stream = HttpConnection::Plain(FromTokio::new(stream));
+    let mut stream = HttpConnection::Plain(TokioStream(FromTokio::new(stream)));
 
     let request = Request::post("/")
         .body(b"PING".as_slice())


### PR DESCRIPTION
I had to do a bunch of refactoring, because I had to create an abstraction for `maybe-BufRead` types (and I had to implement that for the tokio adapter stuff). This is because ChunkedEncoding's new reader function works via BufRead.

A downside of this PR is that `read_to_end` is only available for `TryBufRead` types, which we only define for `HttpConnection` in the library, and the tokio adapter in the tests.

The PR can most likely be simplified, I was just aiming to get it working and it took long enough.