### PR TITLE
feat(esp-mbedtls): Add initial support for using esp-mbedtls in the client instead of embedded_tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ defmt = { version = "0.3", optional = true }
 embedded-tls = { version = "0.17", default-features = false, optional = true }
 rand_chacha = { version = "0.3", default-features = false }
 nourl = "0.1.1"
+esp-mbedtls = { git = "https://github.com/esp-rs/esp-mbedtls.git", features = ["async"], optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ traits from the `embedded-io` crate. No alloc or std lib required!
 It offers two sets of APIs:
 
 * A low-level `request` API which allows you to construct HTTP requests and write them to a `embedded-io` transport.
-* A higher level `client` API which uses the `embedded-nal-async` (+ optional `embedded-tls`) crates to establish TCP + TLS connections.
+* A higher level `client` API which uses the `embedded-nal-async` (+ optional `embedded-tls` / `esp-mbedtls`) crates to establish TCP + TLS connections.
 
 ## example
 
@@ -30,14 +30,68 @@ let response = client
     .unwrap();
 ```
 
-The client is still lacking many features, but can perform basic HTTP GET/PUT/POST/DELETE requests with payloads. However, not all content types and status codes are implemented, and are added on a need basis.  For TLS, it uses `embedded-tls` as the transport.
+The client is still lacking many features, but can perform basic HTTP GET/PUT/POST/DELETE requests with payloads. However, not all content types and status codes are implemented, and are added on a need basis.  For TLS, it uses either `embedded-tls` or `esp-mbedtls` as the transport.
 
 NOTE: TLS verification is not supported in no_std environments for `embedded-tls`.
 
 If you are missing a feature or would like an improvement, please raise an issue or a PR.
 
-## TLS 1.3 and Supported Cipher Suites
-`reqwless` uses `embedded-tls` to establish secure TLS connections for `https://..` urls.
+## TLS 1.2*, 1.3 and Supported Cipher Suites
+`reqwless` uses `embedded-tls` or `esp-mbedtls` to establish secure TLS connections for `https://..` urls.
+
+*TLS 1.2 is only supported with `esp-mbedtls`
+
+:warning: Note that both features cannot be used together and will cause a compilation error.
+
+### esp-mbedtls
+**Can only be used on esp32 boards**
+`esp-mbedtls` supports TLS 1.2 and 1.3. It uses espressif's Rust wrapper over mbedtls, alongside optimizations such as hardware acceleration.
+
+To use, you need to enable the transitive dependency of `esp-mbedtls` for your SoC.
+Currently, the supported SoCs are:
+
+ - `esp32`
+ - `esp32c3`
+ - `esp32s2`
+ - `esp32s3`
+
+Cargo.toml: 
+
+```toml
+reqwless = { version = "0.12.0", default-features = false, features = ["esp-mbedtls", "log"] }
+esp-mbedtls = { git = "https://github.com/esp-rs/esp-mbedtls.git",  features = ["esp32s3"] }
+```
+<!-- TODO: Update this when esp-mbedtls switches to the unified hal -->
+
+#### Example
+```rust,ignore
+/// ... [initialization code. See esp-wifi]
+let state = TcpClientState::<1, 4096, 4096>::new();
+let mut tcp_client = TcpClient::new(stack, &state);
+let dns_socket = DnsSocket::new(&stack);
+let mut rsa = Rsa::new(peripherals.RSA);
+let config = TlsConfig::new(
+    reqwless::TlsVersion::Tls1_3,
+    reqwless::Certificates {
+        ca_chain: reqwless::X509::pem(CERT.as_bytes()).ok(),
+        ..Default::default()
+    },
+    Some(&mut rsa), // Will use hardware acceleration
+);
+let mut client = HttpClient::new_with_tls(&tcp_client, &dns_socket, config);
+
+let mut request = client
+    .request(reqwless::request::Method::GET, "https://www.google.com")
+    .await
+    .unwrap()
+    .content_type(reqwless::headers::ContentType::TextPlain)
+    .headers(&[("Host", "google.com")])
+    .send(&mut buffer)
+    .await
+    .unwrap();
+```
+
+### embedded-tls
 `embedded-tls` only supports TLS 1.3, so to establish a connection the server must have this ssl protocol enabled.
 
 An addition to the tls version requirement, there is also a negotiation of supported algorithms during the establishing phase of the secure communication between the client and server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// Tls Error
     #[cfg(feature = "embedded-tls")]
     Tls(embedded_tls::TlsError),
+    /// Tls Error
+    #[cfg(feature = "esp-mbedtls")]
+    Tls(esp_mbedtls::TlsError),
     /// The provided buffer is too small
     BufferTooSmall,
     /// The request is already sent
@@ -66,6 +69,17 @@ impl<E: embedded_io::Error> From<ReadExactError<E>> for Error {
 #[cfg(feature = "embedded-tls")]
 impl From<embedded_tls::TlsError> for Error {
     fn from(e: embedded_tls::TlsError) -> Error {
+        Error::Tls(e)
+    }
+}
+
+/// Re-export those members since they're used for [client::TlsConfig].
+#[cfg(feature = "esp-mbedtls")]
+pub use esp_mbedtls::{Certificates, Rsa, TlsVersion, X509};
+
+#[cfg(feature = "esp-mbedtls")]
+impl From<esp_mbedtls::TlsError> for Error {
+    fn from(e: esp_mbedtls::TlsError) -> Error {
         Error::Tls(e)
     }
 }


### PR DESCRIPTION
CC #49 

This is based off embedded_tls support. It provides an alternative to use `mbedtls` for the `esp32`, which has its own lot of features and optimizations, like hardware acceleration and client certificate verification.