### PR TITLE
Support accessing the response code as an integer

### DIFF
--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -22,6 +22,8 @@ where
     conn: &'resp mut C,
     /// The method used to create the response.
     method: Method,
+    /// The HTTP response status code, as an integer
+    pub code: u16,
     /// The HTTP response status code.
     pub status: Status,
     /// The HTTP response content type.
@@ -81,7 +83,8 @@ where
         let mut response = httparse::Response::new(&mut headers);
         response.parse(&header_buf[..header_len]).unwrap();
 
-        let status = response.code.unwrap().into();
+        let code = response.code.unwrap();
+        let status = code.into();
         let mut content_type = None;
         let mut content_length = None;
         let mut transfer_encoding = Vec::new();
@@ -119,6 +122,7 @@ where
         Ok(Response {
             conn,
             method,
+            code,
             status,
             content_type,
             content_length,


### PR DESCRIPTION
The `Status` enum only supports a portion of the response codes defined by [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes).  If the server returned a response code other than one of the ones supported by the `Status` enum, the code previously threw away the value.  This updates the code to also store the code as an integer, so that users can handle other values.

I considered simply changing the `Unknown` variant to use `Unknown(u16)`, but avoided it for now since this would break backwards compatibility, and would also prevent using `status as u16` to convert `Status` values to integers.