### PR TITLE
Fix bug when calling fill_buf() when there are no remaining bytes

### DIFF
--- a/src/response/chunked.rs
+++ b/src/response/chunked.rs
@@ -220,12 +220,13 @@ where
 {
     async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
         let remaining = self.handle_chunk_boundary().await?;
-
-        let buf = self.raw_body.fill_buf().await.map_err(|e| Error::Network(e.kind()))?;
-
-        let len = buf.len().min(remaining);
-
-        Ok(&buf[..len])
+        if remaining == 0 {
+            Ok(&[])
+        } else {
+            let buf = self.raw_body.fill_buf().await.map_err(|e| Error::Network(e.kind()))?;
+            let len = buf.len().min(remaining);
+            Ok(&buf[..len])
+        }
     }
 
     fn consume(&mut self, amt: usize) {


### PR DESCRIPTION
`fill_buf()` will not return until there is at least one byte available to read. This will not happen when the entire chunked body is read.

cc @bugadani 