### PR TITLE
Allow `request::Method` to be copied and cloned

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -217,7 +217,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// HTTP request methods
 pub enum Method {


### PR DESCRIPTION
This enables looping over the same request call for retries.