### PR TITLE
fix(request): if host is ipv6 address, enclose it in square brackets

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -2,6 +2,8 @@
 use crate::headers::ContentType;
 use crate::Error;
 use core::fmt::Write as _;
+use core::net::Ipv6Addr;
+use core::str::FromStr;
 use embedded_io::Error as _;
 use embedded_io_async::Write;
 use heapless::String;
@@ -139,7 +141,17 @@ where
             }
         }
         if let Some(host) = &self.host {
-            write_header(c, "Host", host).await?;
+            let is_ipv6 = Ipv6Addr::from_str(host).is_ok();
+            write_str(c, "Host").await?;
+            write_str(c, ": ").await?;
+            if is_ipv6 {
+                write_str(c, "[").await?;
+            }
+            write_str(c, host).await?;
+            if is_ipv6 {
+                write_str(c, "]").await?;
+            }
+            write_str(c, "\r\n").await?;
         }
         if let Some(content_type) = &self.content_type {
             write_header(c, "Content-Type", content_type.as_str()).await?;


### PR DESCRIPTION
Hello,

related RFC requires it this way, and also at least apache would reject non-bracketed ipv6 host address with Bad Request.

I don't know any better way how to do this, except for modifying the `nourl` parser to return hostname type (ipv4, ipv6, domain name).

Also see corresponding work here:
https://github.com/rmja/nourl/pull/2