### PR TITLE
feat(headers): add support for the `text/html` `Content-Type`

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -2,6 +2,7 @@
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ContentType {
+    TextHtml,
     TextPlain,
     ApplicationJson,
     ApplicationCbor,
@@ -13,6 +14,7 @@ impl<'a> From<&'a [u8]> for ContentType {
         match from {
             b"application/json" => ContentType::ApplicationJson,
             b"application/cbor" => ContentType::ApplicationCbor,
+            b"text/html" => ContentType::TextHtml,
             b"text/plain" => ContentType::TextPlain,
             _ => ContentType::ApplicationOctetStream,
         }
@@ -22,6 +24,7 @@ impl<'a> From<&'a [u8]> for ContentType {
 impl ContentType {
     pub fn as_str(&self) -> &str {
         match self {
+            ContentType::TextHtml => "text/html",
             ContentType::TextPlain => "text/plain",
             ContentType::ApplicationJson => "application/json",
             ContentType::ApplicationCbor => "application/cbor",


### PR DESCRIPTION
Thanks for the work on this crate!

This adds support for the [`text/html` `Content-Type`](https://www.iana.org/assignments/media-types/text/html), which otherwise defaults to `application/octet-stream`. I understand that this may be less relevant than e.g.`application/json` in an embedded context, but I believe it's still useful to have.