### PR TITLE
fix: Update esp-mbedtls compatiblity with latest HEAD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ impl From<embedded_tls::TlsError> for Error {
 
 /// Re-export those members since they're used for [client::TlsConfig].
 #[cfg(feature = "esp-mbedtls")]
-pub use esp_mbedtls::{Certificates, TlsVersion, X509};
+pub use esp_mbedtls::{Certificates, TlsVersion, X509, TlsReference};
 
 #[cfg(feature = "esp-mbedtls")]
 impl From<esp_mbedtls::TlsError> for Error {


### PR DESCRIPTION
This updates the compatibility with the latest HEAD of `esp-mbedtls`, after https://github.com/esp-rs/esp-mbedtls/commit/1431835a9a3464820e97203347ec33e313f8e116
