### PR TITLE
Implement Accept request header and Date response header.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ nourl = "0.1.1"
 esp-mbedtls = { version = "0.1", git = "https://github.com/esp-rs/esp-mbedtls.git", features = [
     "async",
 ], optional = true }
+chrono = { version = "0.4", default-features = false, optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["full"] }
@@ -46,7 +47,7 @@ rand = "0.8"
 
 [features]
 default = ["embedded-tls"]
-alloc = ["embedded-tls?/alloc"]
+alloc = ["embedded-tls?/alloc", "chrono?/alloc"]
 defmt = [
     "dep:defmt",
     "embedded-io/defmt-03",
@@ -54,3 +55,6 @@ defmt = [
     "embedded-tls?/defmt",
     "nourl/defmt",
 ]
+date-header-u8 = []
+date-header-chrono = ["dep:chrono", "alloc"]
+accept-header = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -471,6 +471,12 @@ where
         self
     }
 
+    #[cfg(feature = "accept-header")]
+    fn accept(mut self, content_type: ContentType) -> Self {
+        self.request = Some(self.request.unwrap().accept(content_type));
+        self
+    }
+
     fn basic_auth(mut self, username: &'m str, password: &'m str) -> Self {
         self.request = Some(self.request.unwrap().basic_auth(username, password));
         self
@@ -633,6 +639,12 @@ where
 
     fn content_type(mut self, content_type: ContentType) -> Self {
         self.request = self.request.content_type(content_type);
+        self
+    }
+
+    #[cfg(feature = "accept-header")]
+    fn accept(mut self, content_type: ContentType) -> Self {
+        self.request = self.request.accept(content_type);
         self
     }
 

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,4 +1,11 @@
+#[cfg(feature = "date-header-u8")]
+#[cfg(feature = "date-header-chrono")]
+compile_error!("Specify zero or one of features date-header-u8, date-header-chrono");
+#[cfg(feature = "date-header-chrono")]
+use chrono::NaiveDateTime;
+
 /// HTTP content types
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ContentType {
@@ -95,5 +102,62 @@ impl<'a> TryFrom<&'a [u8]> for KeepAlive {
             }
         }
         Ok(keep_alive)
+    }
+}
+
+#[cfg(feature = "date-header-chrono")]
+#[derive(Debug, Eq, PartialEq)]
+pub struct NaiveDateTimeHeaderValue(pub NaiveDateTime);
+
+#[cfg(all(feature = "defmt", feature = "date-header-chrono"))]
+extern crate alloc;
+#[cfg(all(feature = "defmt", feature = "date-header-chrono"))]
+use alloc::string::ToString;
+#[cfg(all(feature = "defmt", feature = "date-header-chrono"))]
+impl defmt::Format for NaiveDateTimeHeaderValue {
+    fn format(self: &Self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "{:?}",
+            self.0.format("%a, %d %b %Y %H:%M:%S GMT").to_string().as_str()
+        );
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg(any(feature = "date-header-u8", feature = "date-header-chrono"))]
+pub struct HeaderDate {
+    #[cfg(feature = "date-header-u8")]
+    pub date: Option<[u8; 29]>, // like "Mon, 03 Jul 2024 12:34:56 GMT"
+    #[cfg(feature = "date-header-chrono")]
+    pub date: Option<NaiveDateTimeHeaderValue>,
+}
+
+#[cfg(feature = "date-header-u8")]
+impl<'a> TryFrom<&'a [u8]> for HeaderDate {
+    type Error = ();
+
+    fn try_from(from: &'a [u8]) -> Result<Self, Self::Error> {
+        let mut buf: [u8; 29] = [b' '; 29];
+        buf.copy_from_slice(&from[..29]);
+        Ok(Self { date: Some(buf) })
+    }
+}
+
+#[cfg(feature = "date-header-chrono")]
+impl<'a> TryFrom<&'a [u8]> for HeaderDate {
+    type Error = ();
+
+    fn try_from(from: &'a [u8]) -> Result<Self, Self::Error> {
+        use core::str;
+        if let Ok(s) = str::from_utf8(&from[5..]) {
+            if let Ok((dt, _rem)) = NaiveDateTime::parse_and_remainder(s, "%d %b %Y %H:%M:%S") {
+                return Ok(Self {
+                    date: Some(NaiveDateTimeHeaderValue(dt)),
+                });
+            }
+        }
+        Err(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ impl From<embedded_tls::TlsError> for Error {
 
 /// Re-export those members since they're used for [client::TlsConfig].
 #[cfg(feature = "esp-mbedtls")]
-pub use esp_mbedtls::{Certificates, TlsVersion, X509, TlsReference};
+pub use esp_mbedtls::{Certificates, TlsReference, TlsVersion, X509};
 
 #[cfg(feature = "esp-mbedtls")]
 impl From<esp_mbedtls::TlsError> for Error {

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -9,6 +9,9 @@ pub use crate::response::chunked::ChunkedBodyReader;
 pub use crate::response::fixed_length::FixedLengthBodyReader;
 use crate::{Error, TryBufRead};
 
+#[cfg(any(feature = "date-header-u8", feature = "date-header-chrono"))]
+use crate::headers::HeaderDate;
+
 mod chunked;
 mod fixed_length;
 
@@ -28,6 +31,9 @@ where
     pub content_type: Option<ContentType>,
     /// The content length.
     pub content_length: Option<usize>,
+    /// The date, if configured.
+    #[cfg(any(feature = "date-header-u8", feature = "date-header-chrono"))]
+    pub date: Option<HeaderDate>,
     /// The transfer encoding.
     pub transfer_encoding: heapless::Vec<TransferEncoding, 4>,
     /// The keep-alive parameters.
@@ -86,6 +92,8 @@ where
         let mut content_length = None;
         let mut transfer_encoding = Vec::new();
         let mut keep_alive = None;
+        #[cfg(any(feature = "date-header-u8", feature = "date-header-chrono"))]
+        let mut date = None;
 
         for header in response.headers {
             if header.name.eq_ignore_ascii_case("content-type") {
@@ -103,6 +111,11 @@ where
                     .map_err(|_| Error::Codec)?;
             } else if header.name.eq_ignore_ascii_case("keep-alive") {
                 keep_alive.replace(header.value.try_into().map_err(|_| Error::Codec)?);
+            } else {
+                #[cfg(any(feature = "date-header-u8", feature = "date-header-chrono"))]
+                if header.name.eq_ignore_ascii_case("date") {
+                    date.replace(header.value.try_into().map_err(|_| Error::Codec)?);
+                }
             }
         }
 
@@ -132,6 +145,8 @@ where
             status,
             content_type,
             content_length,
+            #[cfg(any(feature = "date-header-u8", feature = "date-header-chrono"))]
+            date,
             transfer_encoding,
             keep_alive,
             header_buf,
@@ -613,7 +628,7 @@ mod tests {
 
         match body {
             Error::BufferTooSmall => {}
-            e => panic!("Unexpected error: {e:?}"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
@@ -793,6 +808,38 @@ mod tests {
         assert_eq!(0, reader.read(&mut buf).await.unwrap());
         assert_eq!(0, reader.read(&mut buf).await.unwrap());
         assert_eq!(b"XYYYYYYYYYYYYYYYY", &body);
+    }
+
+    #[tokio::test]
+    async fn can_see_date_header() {
+        let mut conn = FakeSingleReadConnection::new(
+            b"HTTP/1.1 200 OK\r\nDate: Mon, 01 Jan 2025 11:22:33 GMT\r\n\r\nHAPPY NEW YEAR",
+        );
+        let mut header_buf = [0; 200];
+        let response = Response::read(&mut conn, Method::GET, &mut header_buf).await.unwrap();
+
+        #[cfg(any(feature = "date-header-u8", feature = "date-header-chrono"))]
+        let d = response.date.unwrap().date;
+
+        #[cfg(feature = "date-header-u8")]
+        assert_eq!(d.unwrap(), *b"Mon, 01 Jan 2025 11:22:33 GMT");
+
+        #[cfg(feature = "date-header-chrono")]
+        {
+            use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+            let compare: NaiveDateTime = NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+                NaiveTime::from_hms_opt(11, 22, 33).unwrap(),
+            );
+            assert_eq!(d.unwrap().0, compare);
+        }
+
+        #[cfg(not(any(feature = "date-header-u8", feature = "date-header-chrono")))]
+        {
+            let body = response.body().read_to_end().await.unwrap();
+            assert_eq!(b"HAPPY NEW YEAR", body);
+            assert!(conn.is_exhausted());
+        }
     }
 
     struct FakeSingleReadConnection {


### PR DESCRIPTION
Please consider this PR to add support for a couple of headers.

Feature "accept-header" gates the simple Accept request header implementation.

Date is nastier. I implemented it as the raw bytes of the response header behind "date-header-u8". This does no checking of the value, just passes the expected full length of the Date value out as .date: `Option<HeaderDate>`, with `HeaderDate { date: Option<[u8; 29]> }`. Outer `None` indicates no Date header was present in the response, while an inner `None` represents trouble retrieving the value.

For my use case however I'm already using `chrono::NaiveDateTime` in my application, so there's near-zero cost to using it here. That implementation is gated by "date-header-chrono" and presents `response.date` as `Option<HeaderDate>` again, but with the inner .date field any-typed to `Option<NaiveDateTimeHeaderValue>` to work around defmt format trait requirements. Again, inner `None` represents trouble retrieving the value. The actual `NativeDateTime` in `HeaderDate` is `.date.unwrap().0`.