### PR TITLE
The defmt feature should enable defmt in heapless (Fixes issue #108)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,5 @@ defmt = [
     "embedded-io-async/defmt-03",
     "embedded-tls?/defmt",
     "nourl/defmt",
+    "heapless/defmt-03",
 ]


### PR DESCRIPTION
Fixes issue [#108](https://github.com/drogue-iot/reqwless/issues/108)