### PR TITLE
Add support for the host being an IP address.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
 embedded-tls = { version = "0.17", default-features = false, optional = true }
 rand_chacha = { version = "0.3", default-features = false }
-nourl = "0.1.2"
 esp-mbedtls = { version = "0.1", git = "https://github.com/esp-rs/esp-mbedtls.git", features = [
     "async",
 ], optional = true }
+nourl = { git = "https://github.com/Frostie314159/nourl.git", version = "0.1.2" }
 
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["full"] }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -201,6 +201,7 @@ pub struct NoneError;
 pub trait Try {
     type Ok;
     type Error;
+    #[allow(dead_code)]
     fn into_result(self) -> Result<Self::Ok, Self::Error>;
 }
 


### PR DESCRIPTION
Hi,
as discussed in #116 this PR adds support for the URL host to be an IP address. When the PR for `nourl` is merged, I'll mark this as ready for review. 
I also added a check to skip the DNS lookup all together, if the host is an IP address, which should provide better performance, than going through a mock DNS resolver first.
Greetings
Simon