### PR TITLE
Update mbedtls-rs support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ p256 = { version = "0.13", default-features = false, features = [
 embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls.git", default-features = false, features = ["rustpki"], optional = true }
 rand_chacha = { version = "0.3", default-features = false }
 nourl = "0.1.2"
-esp-mbedtls = { version = "0.1", git = "https://github.com/esp-rs/esp-mbedtls.git", optional = true }
+mbedtls-rs = { version = "0.1", git = "https://github.com/esp-rs/mbedtls-rs.git", optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["full"] }
@@ -60,4 +60,5 @@ defmt = [
     "embedded-tls?/defmt",
     "nourl/defmt",
     "heapless/defmt",
+    "mbedtls-rs?/defmt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ p256 = { version = "0.13", default-features = false, features = [
 embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls.git", default-features = false, features = ["rustpki"], optional = true }
 rand_chacha = { version = "0.3", default-features = false }
 nourl = "0.1.2"
-mbedtls-rs = { version = "0.1", git = "https://github.com/esp-rs/mbedtls-rs.git", optional = true }
+mbedtls-rs = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ traits from the `embedded-io` crate. No alloc or std lib required!
 It offers two sets of APIs:
 
 * A low-level `request` API which allows you to construct HTTP requests and write them to a `embedded-io` transport.
-* A higher level `client` API which uses the `embedded-nal-async` (+ optional `embedded-tls` / `esp-mbedtls`) crates to establish TCP + TLS connections.
+* A higher level `client` API which uses the `embedded-nal-async` (+ optional `embedded-tls` / `mbedtls-rs`) crates to establish TCP + TLS connections.
 
 ## example
 
@@ -30,7 +30,7 @@ let response = client
     .unwrap();
 ```
 
-The client is still lacking many features, but can perform basic HTTP GET/PUT/POST/DELETE requests with payloads. However, not all content types and status codes are implemented, and are added on a need basis.  For TLS, it uses either `embedded-tls` or `esp-mbedtls` as the transport.
+The client is still lacking many features, but can perform basic HTTP GET/PUT/POST/DELETE requests with payloads. However, not all content types and status codes are implemented, and are added on a need basis.  For TLS, it uses either `embedded-tls` or `mbedtls-rs` (formerly known as `esp-mbedtls`) as the transport.
 
 NOTE: TLS verification is not supported in no_std environments for `embedded-tls`.
 
@@ -39,33 +39,25 @@ In addition to common headers like `.content_type()` on requests, broader `.head
 If you are missing a feature or would like an improvement, please raise an issue or a PR.
 
 ## TLS 1.2*, 1.3 and Supported Cipher Suites
-`reqwless` uses `embedded-tls` or `esp-mbedtls` to establish secure TLS connections for `https://..` urls.
+`reqwless` uses `embedded-tls` or `mbedtls-rs` (formerly known as `esp-mbedtls`) to establish secure TLS connections for `https://..` urls.
 
-*TLS 1.2 is only supported with `esp-mbedtls`
+*TLS 1.2 is only supported with `mbedtls-rs`
 
 :warning: Note that both features cannot be used together and will cause a compilation error.
 
-:warning: The released version of `reqwless` does not support `esp-mbedtls`. The reason for this is that `esp-mbedtls` is not yet published to crates.io. One should specify `reqwless` as a git dependency to use `esp-mbedtls`.
+:warning: The released version of `reqwless` does not support `mbedtls-rs`. The reason for this is that `mbedtls-rs` is not yet published to crates.io. One should specify `reqwless` as a git dependency to use `mbedtls-rs`.
 
-### esp-mbedtls
+### mbedtls-rs
 **Can only be used on esp32 boards**
-`esp-mbedtls` supports TLS 1.2 and 1.3. It uses espressif's Rust wrapper over mbedtls, alongside optimizations such as hardware acceleration.
-
-To use, you need to enable the transitive dependency of `esp-mbedtls` for your SoC.
-Currently, the supported SoCs are:
-
- - `esp32`
- - `esp32c3`
- - `esp32s2`
- - `esp32s3`
+`mbedtls-rs` supports TLS 1.2 and 1.3. It uses espressif's Rust wrapper over mbedtls, alongside optimizations such as hardware acceleration.
 
 Cargo.toml: 
 
 ```toml
-reqwless = { version = "0.12.0", default-features = false, features = ["esp-mbedtls", "log"] }
-esp-mbedtls = { git = "https://github.com/esp-rs/esp-mbedtls.git",  features = ["esp32s3"] }
+reqwless = { version = "0.14.0", default-features = false, features = ["mbedtls-rs", "log"] }
+mbedtls-rs = { git = "https://github.com/esp-rs/mbedtls-rs.git",  features = ["esp32s3"] }
 ```
-<!-- TODO: Update this when esp-mbedtls switches to the unified hal -->
+
 
 #### Example
 ```rust,ignore

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ If you are missing a feature or would like an improvement, please raise an issue
 
 :warning: Note that both features cannot be used together and will cause a compilation error.
 
-:warning: The released version of `reqwless` does not support `mbedtls-rs`. The reason for this is that `mbedtls-rs` is not yet published to crates.io. One should specify `reqwless` as a git dependency to use `mbedtls-rs`.
-
 ### mbedtls-rs
 `mbedtls-rs` supports TLS 1.2 and 1.3. It uses [Espressif's Rust wrapper](https://github.com/esp-rs/mbedtls-rs) over [mbedtls](https://www.trustedfirmware.org/projects/mbed-tls/) and allows for optimizations such as hardware acceleration.
 
@@ -54,7 +52,7 @@ Cargo.toml:
 
 ```toml
 reqwless = { version = "0.14.0", default-features = false, features = ["mbedtls-rs", "log"] }
-mbedtls-rs = { git = "https://github.com/esp-rs/mbedtls-rs.git" }
+mbedtls-rs = { version = "0.1.0" }
 ```
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -195,6 +195,7 @@ where
                         server_name: None, // don't set it here because it would reference a local variable
                         auth_mode: mbedtls_rs::AuthMode::Required,
                         min_version: tls.version,
+                        alpn_protocols: None, // reqwless uses a fixed application layer protocol anyway 
                     }),
                 )?;
                 session.set_server_name(core::ffi::CStr::from_bytes_with_nul(&servername).unwrap())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl From<embedded_tls::TlsError> for Error {
 
 /// Re-export those members since they're used for [client::TlsConfig].
 #[cfg(feature = "mbedtls-rs")]
-pub use mbedtls_rs::{Certificate, TlsReference, TlsVersion, X509};
+pub use mbedtls_rs::{Certificate, Credentials, TlsReference, TlsVersion, X509};
 
 #[cfg(feature = "mbedtls-rs")]
 impl From<mbedtls_rs::SessionError> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub enum Error {
     #[cfg(feature = "embedded-tls")]
     Tls(embedded_tls::TlsError),
     /// Tls Error
-    #[cfg(feature = "esp-mbedtls")]
-    Tls(esp_mbedtls::TlsError),
+    #[cfg(feature = "mbedtls-rs")]
+    Tls(mbedtls_rs::SessionError),
     /// The provided buffer is too small
     BufferTooSmall,
     /// The request is already sent
@@ -83,12 +83,12 @@ impl From<embedded_tls::TlsError> for Error {
 }
 
 /// Re-export those members since they're used for [client::TlsConfig].
-#[cfg(feature = "esp-mbedtls")]
-pub use esp_mbedtls::{Certificates, TlsReference, TlsVersion, X509};
+#[cfg(feature = "mbedtls-rs")]
+pub use mbedtls_rs::{Certificate, TlsReference, TlsVersion, X509};
 
-#[cfg(feature = "esp-mbedtls")]
-impl From<esp_mbedtls::TlsError> for Error {
-    fn from(e: esp_mbedtls::TlsError) -> Error {
+#[cfg(feature = "mbedtls-rs")]
+impl From<mbedtls_rs::SessionError> for Error {
+    fn from(e: mbedtls_rs::SessionError) -> Error {
         Error::Tls(e)
     }
 }


### PR DESCRIPTION
The [most recent refactor](https://github.com/esp-rs/mbedtls-rs/pull/95) as well as the [renaming](https://github.com/esp-rs/mbedtls-rs/pull/107) of `esp-mbedtls` (now `mbedtls-rs`) broke quite a bit.

This fixes it, making it usable again.

However, there are a few points I would like to discuss before possibly merging this:
- `mbedtls_rs` wants C-Strings for the `servername`, and we only get it as a `&str`, so we need some sort of allocation. Here, I did it similarly to how it was before and copied, but that needs the `alloc` crate. 
  - I think that's fine since any use of `mbedtls` needs some form of allocation anyway, so it can as well be the rust-one.
- Referring to a git repo can break things at any time. Should we at least pin the latest `mbedtls-rs` commit?
- `mbedtls`'s `Session` has a `close()` function, which the library seems to expect to be called (and produces a warning when not). Currently, this is not implemented. 
  - There's a bit of a difficulty and how to do this nicely, since said `close()` is `async` and hence cannot be called from, say, `drop()`
  - My current solution (not in this PR) is to add a new API function to `HttpClient`, `close`, but don't know if it's the best solution.