### PR TITLE
Add aes256-sha384 TLS cipher feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,12 @@ p256 = { version = "0.13", default-features = false, features = [
     "ecdsa",
     "sha256",
 ] }
-embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls.git", default-features = false, features = ["rustpki"], optional = true }
+# Oldest working revision with reqwless-compatible features, rustpki, and AES-256/SHA-384 support.
+embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls.git", rev = "dd97196dfd56c836b6267dc89f1fe618094f72a3", default-features = false, features = ["rustpki"], optional = true }
 rand_chacha = { version = "0.3", default-features = false }
 nourl = "0.1.2"
-esp-mbedtls = { version = "0.1", git = "https://github.com/esp-rs/esp-mbedtls.git", optional = true }
+# Pinned before esp-rs/mbedtls-rs#107 renamed the package to mbedtls-rs.
+esp-mbedtls = { version = "0.1", git = "https://github.com/esp-rs/esp-mbedtls.git", rev = "0d86dccfdaa404d7c7da28bed30926ac51bdc411", optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["full"] }
@@ -53,6 +55,7 @@ default = ["embedded-tls"]
 rsa = ["embedded-tls?/alloc", "embedded-tls?/rsa"]
 p384 = ["embedded-tls?/p384"]
 ed25519 = ["embedded-tls?/ed25519"]
+aes256-sha384 = ["embedded-tls"]
 defmt = [
     "dep:defmt",
     "embedded-io/defmt",

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ If the command fails, then try and run without the limited set of signature algo
 openssl s_client -tls1_3 -ciphersuites TLS_AES_128_GCM_SHA256 -connect hostname:443
 ```
 
+`reqwless` uses `TLS_AES_128_GCM_SHA256` by default. To connect to servers that only accept
+`TLS_AES_256_GCM_SHA384`, enable the `aes256-sha384` feature:
+
+```toml
+reqwless = { version = "0.14.0", features = ["aes256-sha384"] }
+```
+
 If this works, then there are two options. Either enable the signature algorithms on the server by changing the private key from RSA to ECDSA or ed25519, or enable RSA keys on the client by specifying the `alloc` feature.
 This enables `alloc` on `embedded-tls` which in turn enables RSA signature algorithms.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,10 @@
-use crate::Error;
 /// Client using embedded-nal-async traits to establish connections and perform HTTP requests.
 ///
 use crate::body_writer::{BufferingChunkedBodyWriter, ChunkedBodyWriter, FixedBodyWriter};
 use crate::headers::ContentType;
 use crate::request::*;
 use crate::response::*;
+use crate::Error;
 use buffered_io::asynch::BufferedWrite;
 use core::net::SocketAddr;
 use embedded_io::Error as _;
@@ -12,14 +12,17 @@ use embedded_io::ErrorType;
 use embedded_io_async::{Read, Write};
 use embedded_nal_async::{Dns, TcpConnect};
 #[cfg(feature = "embedded-tls")]
-use embedded_tls::{
-    Aes128GcmSha256, CryptoProvider, NoClock, SignatureScheme, TlsError, TlsVerifier, pki::CertVerifier,
-};
+use embedded_tls::{pki::CertVerifier, CryptoProvider, NoClock, SignatureScheme, TlsError, TlsVerifier};
 use nourl::{Url, UrlScheme};
 #[cfg(feature = "embedded-tls")]
-use p256::ecdsa::{DerSignature, signature::SignerMut};
+use p256::ecdsa::{signature::SignerMut, DerSignature};
 #[cfg(feature = "embedded-tls")]
 use rand_core::CryptoRngCore;
+
+#[cfg(all(feature = "embedded-tls", not(feature = "aes256-sha384")))]
+type DefaultCipher = embedded_tls::Aes128GcmSha256;
+#[cfg(all(feature = "embedded-tls", feature = "aes256-sha384"))]
+type DefaultCipher = embedded_tls::Aes256GcmSha384;
 
 /// An async HTTP client that can establish a TCP connection and perform
 /// HTTP requests.
@@ -59,12 +62,12 @@ pub struct TlsConfig<'a> {
 #[cfg(feature = "embedded-tls")]
 struct Provider {
     rng: rand_chacha::ChaCha8Rng,
-    verifier: CertVerifier<Aes128GcmSha256, NoClock, 4096>,
+    verifier: CertVerifier<DefaultCipher, NoClock, 4096>,
 }
 
 #[cfg(feature = "embedded-tls")]
 impl CryptoProvider for Provider {
-    type CipherSuite = Aes128GcmSha256;
+    type CipherSuite = DefaultCipher;
     type Signature = DerSignature;
 
     fn rng(&mut self) -> impl CryptoRngCore {
@@ -76,7 +79,7 @@ impl CryptoProvider for Provider {
     }
 
     fn signer(&mut self, key_der: &[u8]) -> Result<(impl SignerMut<Self::Signature>, SignatureScheme), TlsError> {
-        use p256::{SecretKey, ecdsa::SigningKey};
+        use p256::{ecdsa::SigningKey, SecretKey};
 
         let secret_key = SecretKey::from_sec1_der(key_der).map_err(|_| TlsError::InvalidPrivateKey)?;
 
@@ -202,7 +205,7 @@ where
                 let rng = ChaCha8Rng::seed_from_u64(tls.seed);
                 let mut config = TlsConfig::new().with_server_name(url.host());
 
-                let mut conn: embedded_tls::TlsConnection<'conn, T::Connection<'conn>, embedded_tls::Aes128GcmSha256> =
+                let mut conn: embedded_tls::TlsConnection<'conn, T::Connection<'conn>, DefaultCipher> =
                     embedded_tls::TlsConnection::new(conn, tls.read_buffer, tls.write_buffer);
 
                 match tls.verify {
@@ -301,7 +304,7 @@ where
     #[cfg(feature = "esp-mbedtls")]
     Tls(esp_mbedtls::asynch::Session<'conn, C>),
     #[cfg(feature = "embedded-tls")]
-    Tls(embedded_tls::TlsConnection<'conn, C, embedded_tls::Aes128GcmSha256>),
+    Tls(embedded_tls::TlsConnection<'conn, C, DefaultCipher>),
     #[cfg(all(not(feature = "embedded-tls"), not(feature = "esp-mbedtls")))]
     Tls((&'conn mut (), core::convert::Infallible)), // Variant is impossible to create, but we need it to avoid "unused lifetime" warning
 }


### PR DESCRIPTION
## Summary

- add an `aes256-sha384` feature for embedded-tls
- keep `TLS_AES_128_GCM_SHA256` as the default embedded-tls cipher suite
- switch embedded-tls to `TLS_AES_256_GCM_SHA384` when `aes256-sha384` is enabled
- pin embedded-tls to the oldest working revision with reqwless-compatible features, rustpki, and AES-256/SHA-384 support
- pin esp-mbedtls before the package rename in esp-rs/mbedtls-rs#107

## Notes

This keeps the client API unchanged. The cipher suite is selected at compile time through Cargo features, avoiding the runtime wrapper enum needed for configurable cipher selection.

`dd97196dfd56c836b6267dc89f1fe618094f72a3` is the oldest practical embedded-tls pin I found. Earlier useful candidates either miss reqwless-facing optional features or fail to compile with `der 0.8.0` without the later `der/heapless` fix.

## Validation

- `cargo check`
- `cargo check --no-default-features --features embedded-tls`
- `cargo check --no-default-features --features embedded-tls,aes256-sha384`
- `git diff --check`
- `rustfmt --check src/client.rs`
